### PR TITLE
Replace Bootstrap with custom editorial admin theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Meow — engineering notes for Claude
+
+## Comments
+Only add a comment when there is an odd, exceptional need to document something
+unusual — a non-obvious workaround, a surprising constraint, a "why" the code
+can't express on its own. Do not narrate what the code already says. Default to
+no comment.

--- a/app/assets/images/hyper_kitten_meow/icons/alert-triangle.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/alert-triangle.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-alert-triangle"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+  <path d="M12 9v4" />
+  <path d="M12 17h.01" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/arrow-left.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/arrow-left.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-arrow-left"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 19-7-7 7-7" />
+  <path d="M19 12H5" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/check-circle-2.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/check-circle-2.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-check-circle-2"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="m9 12 2 2 4-4" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/check.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/check.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-check"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 6 9 17l-5-5" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/chevron-down.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/chevron-down.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-chevron-down"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 9 6 6 6-6" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/chevron-left.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/chevron-left.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-chevron-left"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 18-6-6 6-6" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/chevron-right.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/chevron-right.svg
@@ -1,0 +1,15 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-chevron-right"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m9 18 6-6-6-6" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/eye-off.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/eye-off.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-eye-off"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+  <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+  <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+  <path d="m2 2 20 20" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/eye.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/eye.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-eye"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+  <circle cx="12" cy="12" r="3" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/file-text.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/file-text.svg
@@ -1,0 +1,19 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-file-text"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M10 9H8" />
+  <path d="M16 13H8" />
+  <path d="M16 17H8" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/log-out.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/log-out.svg
@@ -1,0 +1,17 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-log-out"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m16 17 5-5-5-5" />
+  <path d="M21 12H9" />
+  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/newspaper.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/newspaper.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-newspaper"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 18h-5" />
+  <path d="M18 14h-8" />
+  <path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2" />
+  <rect width="8" height="4" x="10" y="6" rx="1" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/pen-line.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/pen-line.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-pen-line"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 21h8" />
+  <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/plus.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/plus.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-plus"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 12h14" />
+  <path d="M12 5v14" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/search.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/search.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-search"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m21 21-4.34-4.34" />
+  <circle cx="11" cy="11" r="8" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/tag.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/tag.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-tag"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z" />
+  <circle cx="7.5" cy="7.5" r=".5" fill="currentColor" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/trash-2.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/trash-2.svg
@@ -1,0 +1,19 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-trash-2"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 11v6" />
+  <path d="M14 11v6" />
+  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+  <path d="M3 6h18" />
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/users.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/users.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-users"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+  <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+  <circle cx="9" cy="7" r="4" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/icons/x.svg
+++ b/app/assets/images/hyper_kitten_meow/icons/x.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.17.0 - ISC -->
+<svg
+  class="lucide lucide-x"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6 6 18" />
+  <path d="m6 6 12 12" />
+</svg>

--- a/app/assets/images/hyper_kitten_meow/meow-mark-light.svg
+++ b/app/assets/images/hyper_kitten_meow/meow-mark-light.svg
@@ -1,0 +1,26 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meow">
+  
+  <g stroke="#F3EEE4" stroke-width="3.4" stroke-linejoin="round" stroke-linecap="round" fill="none">
+    
+    <path d="M16.5 24 L13.5 9.5 L28 19.5"></path>
+    
+    <path d="M47.5 24 L50.5 9.5 L36 19.5"></path>
+    
+    <path d="M16 26.5 C16 22, 19 19, 24 18.5 C27.5 18.2, 36.5 18.2, 40 18.5 C45 19, 48 22, 48 26.5 L48 38 C48 46, 41.5 51.5, 32 51.5 C22.5 51.5, 16 46, 16 38 Z"></path>
+  </g>
+  
+  <g stroke="#F3EEE4" stroke-width="3.2" stroke-linecap="round" fill="none">
+    <path d="M23 33.5 C24.3 35.6, 27 35.6, 28.3 33.5"></path>
+    <path d="M35.7 33.5 C37 35.6, 39.7 35.6, 41 33.5"></path>
+  </g>
+  
+  <path d="M32 39.5 L29.4 42 L34.6 42 Z" fill="#EC5A1E"></path>
+  
+  <g stroke="#F3EEE4" stroke-width="2.2" stroke-linecap="round">
+    <path d="M30 44 C31 45.4, 33 45.4, 34 44"></path>
+    <path d="M11 36 L20 37.5"></path>
+    <path d="M11 41.5 L20 41"></path>
+    <path d="M53 36 L44 37.5"></path>
+    <path d="M53 41.5 L44 41"></path>
+  </g>
+</svg>

--- a/app/assets/images/hyper_kitten_meow/meow-mark-orange.svg
+++ b/app/assets/images/hyper_kitten_meow/meow-mark-orange.svg
@@ -1,0 +1,26 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meow">
+  
+  <g stroke="#EC5A1E" stroke-width="3.4" stroke-linejoin="round" stroke-linecap="round" fill="none">
+    
+    <path d="M16.5 24 L13.5 9.5 L28 19.5"></path>
+    
+    <path d="M47.5 24 L50.5 9.5 L36 19.5"></path>
+    
+    <path d="M16 26.5 C16 22, 19 19, 24 18.5 C27.5 18.2, 36.5 18.2, 40 18.5 C45 19, 48 22, 48 26.5 L48 38 C48 46, 41.5 51.5, 32 51.5 C22.5 51.5, 16 46, 16 38 Z"></path>
+  </g>
+  
+  <g stroke="#EC5A1E" stroke-width="3.2" stroke-linecap="round" fill="none">
+    <path d="M23 33.5 C24.3 35.6, 27 35.6, 28.3 33.5"></path>
+    <path d="M35.7 33.5 C37 35.6, 39.7 35.6, 41 33.5"></path>
+  </g>
+  
+  <path d="M32 39.5 L29.4 42 L34.6 42 Z" fill="#1A1714"></path>
+  
+  <g stroke="#EC5A1E" stroke-width="2.2" stroke-linecap="round">
+    <path d="M30 44 C31 45.4, 33 45.4, 34 44"></path>
+    <path d="M11 36 L20 37.5"></path>
+    <path d="M11 41.5 L20 41"></path>
+    <path d="M53 36 L44 37.5"></path>
+    <path d="M53 41.5 L44 41"></path>
+  </g>
+</svg>

--- a/app/assets/images/hyper_kitten_meow/meow-mark.svg
+++ b/app/assets/images/hyper_kitten_meow/meow-mark.svg
@@ -1,0 +1,26 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Meow">
+  
+  <g stroke="#1A1714" stroke-width="3.4" stroke-linejoin="round" stroke-linecap="round" fill="none">
+    
+    <path d="M16.5 24 L13.5 9.5 L28 19.5"></path>
+    
+    <path d="M47.5 24 L50.5 9.5 L36 19.5"></path>
+    
+    <path d="M16 26.5 C16 22, 19 19, 24 18.5 C27.5 18.2, 36.5 18.2, 40 18.5 C45 19, 48 22, 48 26.5 L48 38 C48 46, 41.5 51.5, 32 51.5 C22.5 51.5, 16 46, 16 38 Z"></path>
+  </g>
+  
+  <g stroke="#1A1714" stroke-width="3.2" stroke-linecap="round" fill="none">
+    <path d="M23 33.5 C24.3 35.6, 27 35.6, 28.3 33.5"></path>
+    <path d="M35.7 33.5 C37 35.6, 39.7 35.6, 41 33.5"></path>
+  </g>
+  
+  <path d="M32 39.5 L29.4 42 L34.6 42 Z" fill="#EC5A1E"></path>
+  
+  <g stroke="#1A1714" stroke-width="2.2" stroke-linecap="round">
+    <path d="M30 44 C31 45.4, 33 45.4, 34 44"></path>
+    <path d="M11 36 L20 37.5"></path>
+    <path d="M11 41.5 L20 41"></path>
+    <path d="M53 36 L44 37.5"></path>
+    <path d="M53 41.5 L44 41"></path>
+  </g>
+</svg>

--- a/app/assets/javascripts/hyper_kitten_meow/application.js
+++ b/app/assets/javascripts/hyper_kitten_meow/application.js
@@ -2,8 +2,4 @@ import "@hotwired/turbo-rails"
 import "@hotwired/stimulus"
 import "@rails/actiontext"
 import "@rails/activestorage"
-import * as bootstrap from "bootstrap"
 import "hyper_kitten_meow/controllers"
-
-// Hack to appease Popper
-window.process = { env: {} }

--- a/app/assets/stylesheets/hyper_kitten_meow/meow.css
+++ b/app/assets/stylesheets/hyper_kitten_meow/meow.css
@@ -140,11 +140,19 @@ hr { border: none; border-top: 1px solid var(--hairline); margin: var(--s-5) 0; 
 code, kbd, samp { font-family: var(--mono); font-size: 0.92em; }
 
 /* Semantic type helpers (mirror the design system classes) */
+.ds-display { font-family: var(--serif); font-weight: 400; font-size: 56px; line-height: 1.02; letter-spacing: -0.01em; color: var(--fg1); }
+.ds-h1 { font-family: var(--serif); font-weight: 500; font-size: 38px; line-height: 1.08; letter-spacing: -0.005em; color: var(--fg1); }
+.ds-h2 { font-family: var(--serif); font-weight: 500; font-size: 27px; line-height: 1.15; color: var(--fg1); }
+.ds-h3 { font-family: var(--sans); font-weight: 600; font-size: 19px; line-height: 1.25; letter-spacing: -0.01em; color: var(--fg1); }
 .ds-eyebrow {
   font-family: var(--mono); font-weight: 400; font-size: 11px; line-height: 1;
   letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg3);
 }
+.ds-body { font-family: var(--sans); font-weight: 400; font-size: 15px; line-height: 1.55; color: var(--fg1); }
+.ds-body-serif { font-family: var(--serif); font-weight: 400; font-size: 18px; line-height: 1.6; color: var(--fg1); }
+.ds-small { font-family: var(--sans); font-weight: 400; font-size: 13px; line-height: 1.45; color: var(--fg2); }
 .ds-mono { font-family: var(--mono); font-size: 13px; letter-spacing: -0.01em; color: var(--fg2); }
+.ds-stat { font-family: var(--mono); font-weight: 700; font-size: 44px; line-height: 1; letter-spacing: -0.03em; color: var(--fg1); font-feature-settings: "tnum" 1; }
 
 /* ============================================================
    3. UTILITIES (subset the engine markup relies on)

--- a/app/assets/stylesheets/hyper_kitten_meow/meow.css
+++ b/app/assets/stylesheets/hyper_kitten_meow/meow.css
@@ -1,0 +1,554 @@
+/* ============================================================
+   MEOW — Admin theme
+   Editorial monochrome + signal orange, replacing the engine's
+   stock Bootstrap chrome. Plain CSS, no framework.
+
+   Sections:
+     1. Tokens (color, type, spacing, radius, shadow, motion)
+     2. Reset & base typography
+     3. Utility classes (the subset the engine markup uses)
+     4. Layout chrome (sidebar shell, login split, page header)
+     5. Components (buttons, forms, tables, cards, flash, tags,
+        badges, pagination, quill)
+     6. Public (blog) surface
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..700;1,6..72,300..600&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,500&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap');
+
+/* ============================================================
+   1. TOKENS
+   ============================================================ */
+:root {
+  /* Brand palette */
+  --ink:        #1A1714;
+  --ink-soft:   #2A2622;
+  --paper:      #F6F2EA;
+  --paper-deep: #EDE7DB;
+  --card:       #FFFFFF;
+
+  --orange:      #EC5A1E;
+  --orange-deep: #C9420C;
+  --orange-tint: #FBE6DA;
+
+  /* Warm neutral scale */
+  --n-900: #1A1714; --n-800: #353029; --n-700: #50493F;
+  --n-600: #6E665A; --n-500: #8C8478; --n-400: #ABA395;
+  --n-300: #C9C1B3; --n-200: #E2DBCD; --n-100: #EFE9DD; --n-050: #F6F2EA;
+
+  /* Semantic text */
+  --fg1: var(--n-900);
+  --fg2: var(--n-700);
+  --fg3: var(--n-500);
+  --fg-on-dark:      #F3EEE4;
+  --fg-on-dark-soft: #B8AF9E;
+
+  /* Semantic status */
+  --success: #3E7A4E; --warning: #B5791A; --danger: #B23A2E; --info: var(--ink);
+  --success-tint: #E4EFE5; --warning-tint: #F6ECD6; --danger-tint: #F5E0DC;
+  --info-tint: var(--paper-deep);
+
+  /* Lines & borders */
+  --hairline:        #E0D9CB;
+  --hairline-strong: #CFC6B5;
+  --border-dark:     rgba(243,238,228,0.14);
+  --rule-ink:        var(--ink);
+
+  /* Radii */
+  --r-0: 0px; --r-sm: 4px; --r-md: 8px; --r-lg: 14px; --r-pill: 999px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(26,23,20,0.06);
+  --shadow-md: 0 2px 8px rgba(26,23,20,0.07), 0 1px 2px rgba(26,23,20,0.05);
+  --shadow-lg: 0 14px 40px rgba(26,23,20,0.13), 0 2px 6px rgba(26,23,20,0.06);
+  --shadow-pop: 0 8px 28px rgba(26,23,20,0.16);
+
+  /* Spacing scale (4px base) */
+  --s-1: 4px; --s-2: 8px; --s-3: 12px; --s-4: 16px;
+  --s-5: 24px; --s-6: 32px; --s-7: 48px; --s-8: 64px; --s-9: 96px;
+
+  /* Icon sizes (Lucide, stroke 1.5–2px; pick by context) */
+  --icon-xs: 14px;  /* micro mono-meta inline */
+  --icon-sm: 16px;  /* dense table actions, small/ghost buttons */
+  --icon-md: 18px;  /* DEFAULT — inline with body, sidebar nav */
+  --icon-lg: 20px;  /* primary buttons, toolbars */
+  --icon-xl: 24px;  /* section heads, empty-state glyphs */
+
+  /* Control & layout sizing */
+  --control-h-sm: 28px; --control-h: 36px; --control-h-lg: 44px; --tap-min: 44px;
+  --avatar-sm: 24px; --avatar-md: 32px; --avatar-lg: 48px;
+  --sidebar-w: 240px;       /* fixed dark admin sidebar */
+  --content-max: 760px;     /* comfortable reading column (editor, prose) */
+  --container-max: 1200px;  /* outer app content cap */
+
+  /* Type families */
+  --serif: 'Newsreader', Georgia, 'Times New Roman', serif;
+  --sans:  'IBM Plex Sans', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --mono:  'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Depth / tactile surfaces */
+  --btn-primary-bg:    linear-gradient(180deg, #F4703A 0%, #EC5A1E 52%, #DA4E15 100%);
+  --btn-primary-bg-h:  linear-gradient(180deg, #EF6630 0%, #DF5018 52%, #C9420C 100%);
+  --btn-primary-sh:    0 1px 0 rgba(255,255,255,0.30) inset, 0 1px 2px rgba(201,66,12,0.45), 0 3px 8px rgba(201,66,12,0.26);
+  --btn-dark-bg:       linear-gradient(180deg, #353029 0%, #211D19 60%, #1A1714 100%);
+  --btn-dark-bg-h:     linear-gradient(180deg, #423B33 0%, #2A2520 100%);
+  --btn-dark-sh:       0 1px 0 rgba(255,255,255,0.10) inset, 0 1px 2px rgba(26,23,20,0.4), 0 3px 8px rgba(26,23,20,0.22);
+  --btn-light-bg:      linear-gradient(180deg, #FFFFFF 0%, #F3EEE4 100%);
+  --btn-light-bg-h:    linear-gradient(180deg, #FBF8F2 0%, #EBE4D7 100%);
+  --btn-light-sh:      0 1px 0 rgba(255,255,255,0.8) inset, 0 1px 2px rgba(26,23,20,0.07), 0 2px 5px rgba(26,23,20,0.08);
+  --press-sh:          0 1px 2px rgba(26,23,20,0.22) inset;
+
+  --input-bg:          linear-gradient(180deg, #F1EBE0 0%, #F8F4EC 38%);
+  --input-sh:          inset 0 1.5px 2.5px rgba(26,23,20,0.09), inset 0 0 0 1px rgba(26,23,20,0.015);
+  --input-sh-focus:    inset 0 1px 2px rgba(26,23,20,0.05), 0 0 0 3px var(--orange-tint), 0 1px 1px rgba(255,255,255,0.6);
+
+  --card-raised:       0 1px 0 rgba(255,255,255,0.7) inset, 0 1px 1px rgba(26,23,20,0.04), 0 4px 14px rgba(26,23,20,0.08);
+
+  /* Motion */
+  --ease:     cubic-bezier(0.2, 0.7, 0.2, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --dur-fast: 120ms; --dur: 200ms; --dur-slow: 320ms;
+}
+
+/* ============================================================
+   2. RESET & BASE
+   ============================================================ */
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { height: 100%; }
+html.h-100, body.h-100 { height: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--fg1);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--orange-deep); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1, h2, h3, h4 { margin: 0 0 0.4em; color: var(--fg1); }
+h1 { font-family: var(--serif); font-weight: 500; font-size: 38px; line-height: 1.08; letter-spacing: -0.005em; }
+h2 { font-family: var(--serif); font-weight: 500; font-size: 27px; line-height: 1.15; }
+h3 { font-family: var(--sans); font-weight: 600; font-size: 19px; line-height: 1.25; letter-spacing: -0.01em; }
+p  { margin: 0 0 1em; }
+hr { border: none; border-top: 1px solid var(--hairline); margin: var(--s-5) 0; }
+code, kbd, samp { font-family: var(--mono); font-size: 0.92em; }
+
+/* Semantic type helpers (mirror the design system classes) */
+.ds-eyebrow {
+  font-family: var(--mono); font-weight: 400; font-size: 11px; line-height: 1;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg3);
+}
+.ds-mono { font-family: var(--mono); font-size: 13px; letter-spacing: -0.01em; color: var(--fg2); }
+
+/* ============================================================
+   3. UTILITIES (subset the engine markup relies on)
+   ============================================================ */
+.d-flex { display: flex !important; }
+.d-inline { display: inline !important; }
+.d-block { display: block !important; }
+.d-none { display: none !important; }
+.flex-column { flex-direction: column !important; }
+.justify-content-between { justify-content: space-between !important; }
+.justify-content-center { justify-content: center !important; }
+.align-items-center { align-items: center !important; }
+.gap-1 { gap: var(--s-1) !important; }
+.mb-auto { margin-bottom: auto !important; }
+.mt-auto { margin-top: auto !important; }
+.mb-0 { margin-bottom: 0 !important; }
+.mb-3 { margin-bottom: var(--s-4) !important; }
+.mb-4 { margin-bottom: var(--s-5) !important; }
+.mt-3 { margin-top: var(--s-4) !important; }
+.mt-4 { margin-top: var(--s-5) !important; }
+.my-3 { margin-top: var(--s-4) !important; margin-bottom: var(--s-4) !important; }
+.py-3 { padding-top: var(--s-4) !important; padding-bottom: var(--s-4) !important; }
+.px-4 { padding-left: var(--s-5) !important; padding-right: var(--s-5) !important; }
+.h-100 { height: 100% !important; }
+.text-danger { color: var(--danger) !important; }
+.text-small { font-size: 13px !important; }
+.text-decoration-none { text-decoration: none !important; }
+.border { border: 1px solid var(--hairline) !important; }
+.shadow { box-shadow: var(--shadow-md) !important; }
+
+/* ============================================================
+   4. LAYOUT CHROME
+   ============================================================ */
+
+/* --- Admin shell: fixed sidebar + fluid content --- */
+.mw-shell { display: flex; min-height: 100vh; align-items: stretch; }
+
+.mw-sidebar {
+  width: var(--sidebar-w); flex: none; background: var(--ink); color: var(--fg-on-dark);
+  display: flex; flex-direction: column; padding: 22px 16px;
+}
+.mw-sidebar__brand { padding: 4px 10px 22px; }
+.mw-sidebar__section { color: var(--fg-on-dark-soft); padding: 0 12px 10px; display: block; }
+.mw-nav { display: flex; flex-direction: column; gap: 3px; }
+.mw-nav__item {
+  display: flex; align-items: center; gap: 11px; padding: 9px 12px;
+  border-radius: var(--r-sm); font-weight: 500; font-size: 14.5px;
+  color: var(--fg-on-dark-soft); cursor: pointer;
+  transition: all var(--dur-fast) var(--ease);
+}
+.mw-nav__item:hover { background: #ffffff12; color: var(--fg-on-dark); text-decoration: none; }
+.mw-nav__item.is-active { background: var(--orange-tint); color: var(--ink); }
+.mw-nav__item .mw-icon { color: currentColor; }
+
+.mw-sidebar__foot { margin-top: auto; padding-top: 18px; border-top: 1px solid var(--border-dark); }
+.mw-userchip { display: flex; align-items: center; gap: 11px; padding: 4px 8px; }
+.mw-userchip__avatar {
+  width: var(--avatar-md); height: var(--avatar-md); border-radius: 50%; flex: none; background: var(--orange);
+  display: flex; align-items: center; justify-content: center; color: #fff;
+  font-weight: 700; font-size: 13px;
+}
+.mw-userchip__meta { min-width: 0; flex: 1; }
+.mw-userchip__name { font-size: 13.5px; font-weight: 600; color: var(--fg-on-dark); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mw-userchip__role { font-family: var(--mono); font-size: 10.5px; color: var(--fg-on-dark-soft); }
+.mw-userchip__logout { color: var(--fg-on-dark-soft); display: inline-flex; cursor: pointer; }
+.mw-userchip__logout:hover { color: var(--orange); }
+
+.mw-content { flex: 1; min-width: 0; padding: 32px 40px; }
+.mw-content__inner { max-width: var(--container-max); }
+
+/* --- Page header --- */
+.mw-pageheader {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  margin-bottom: 28px; padding-bottom: 18px; border-bottom: 1px solid var(--hairline);
+  gap: 16px;
+}
+.mw-pageheader__eyebrow { display: block; margin-bottom: 10px; }
+.mw-pageheader h1 { margin: 0; }
+.mw-pageheader__actions { display: flex; gap: 10px; flex: none; }
+
+/* --- Login split screen --- */
+.mw-login { display: flex; min-height: 100vh; background: var(--paper); }
+.mw-login__aside {
+  flex: 1 1 50%; background: var(--ink); color: var(--fg-on-dark); position: relative;
+  padding: 48px 52px; display: flex; flex-direction: column; justify-content: space-between;
+  overflow: hidden;
+}
+.mw-login__headline {
+  font-family: var(--serif); font-weight: 400; font-size: 52px; line-height: 1.04;
+  letter-spacing: -0.015em; margin: 18px 0 0; color: var(--fg-on-dark);
+}
+.mw-login__headline em { color: var(--orange); font-style: italic; }
+.mw-login__lede { font-size: 15px; line-height: 1.6; color: var(--fg-on-dark-soft); max-width: 360px; margin-top: 22px; }
+.mw-login__footmark { font-family: var(--mono); font-size: 11px; color: var(--fg-on-dark-soft); letter-spacing: 0.04em; }
+.mw-login__ghost { position: absolute; right: -90px; bottom: -70px; width: 360px; opacity: 0.05; pointer-events: none; }
+.mw-login__main { flex: 1 1 50%; display: flex; align-items: center; justify-content: center; padding: 40px; }
+.mw-login__form { width: 320px; max-width: 100%; }
+.mw-login__form .ds-eyebrow { display: block; margin-bottom: 12px; }
+.mw-login__form h2 { margin: 0 0 28px; }
+.mw-login__form .btn, .mw-login__form input[type="submit"] { width: 100%; height: var(--control-h-lg); margin-top: 6px; }
+.mw-login__hint { margin-top: 22px; font-family: var(--mono); font-size: 11px; color: var(--fg3); text-align: center; }
+.mw-login__aside .ds-eyebrow { color: var(--orange); }
+.mw-login .mw-flash { margin-bottom: 18px; }
+
+/* --- First-run setup --- */
+.mw-setup { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 40px 24px; background: var(--paper); }
+.mw-setup__inner { width: 420px; max-width: 100%; }
+.mw-setup__brand { display: flex; justify-content: center; margin-bottom: 28px; }
+.mw-setup__card { background: var(--card); border: 1px solid var(--hairline); border-radius: var(--r-md); box-shadow: var(--card-raised); padding: 32px; }
+.mw-setup__card .ds-eyebrow { display: block; margin-bottom: 10px; }
+.mw-setup__card h2 { margin: 0 0 8px; }
+.mw-setup__lede { color: var(--fg2); font-size: 14px; margin: 0 0 22px; }
+.mw-setup__card .btn, .mw-setup__card input[type="submit"] { width: 100%; height: var(--control-h-lg); margin-top: 6px; }
+
+/* Brand wordmark */
+.mw-wordmark { display: inline-flex; align-items: center; gap: 9px; }
+.mw-wordmark img { display: block; width: 30px; height: 30px; }
+.mw-wordmark__text { font-family: var(--serif); font-weight: 500; font-size: 24px; line-height: 1; letter-spacing: -0.015em; color: var(--ink); }
+.mw-wordmark__text .dot { color: var(--orange); }
+.mw-wordmark--light .mw-wordmark__text { color: var(--fg-on-dark); }
+
+/* ============================================================
+   5. COMPONENTS
+   ============================================================ */
+
+/* --- Buttons --- */
+.btn {
+  font-family: var(--sans); font-weight: 600; font-size: 14px; line-height: 1; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  height: var(--control-h); padding: 0 16px; border-radius: var(--r-sm); border: 1px solid transparent;
+  white-space: nowrap; position: relative; transition: all var(--dur-fast) var(--ease);
+  text-decoration: none;
+}
+.btn:hover { text-decoration: none; }
+.btn:active { transform: translateY(1px); box-shadow: var(--press-sh) !important; }
+.btn:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--paper), 0 0 0 4px var(--orange); }
+.btn-sm { font-size: 12.5px; height: var(--control-h-sm); padding: 0 12px; }
+
+.btn-primary {
+  background: var(--btn-primary-bg); color: #fff; border-color: var(--orange-deep);
+  box-shadow: var(--btn-primary-sh); text-shadow: 0 1px 1px rgba(140,40,5,0.3);
+}
+.btn-primary:hover { background: var(--btn-primary-bg-h); color: #fff; }
+
+.btn-secondary {
+  background: var(--btn-dark-bg); color: var(--fg-on-dark); border-color: #000;
+  box-shadow: var(--btn-dark-sh);
+}
+.btn-secondary:hover { background: var(--btn-dark-bg-h); color: var(--fg-on-dark); }
+
+.btn-outline, .btn-outline-primary, .btn-outline-secondary, .btn-outline-info {
+  background: var(--btn-light-bg); color: var(--fg1); border-color: var(--hairline-strong);
+  box-shadow: var(--btn-light-sh);
+}
+.btn-outline:hover, .btn-outline-primary:hover, .btn-outline-secondary:hover, .btn-outline-info:hover {
+  background: var(--btn-light-bg-h); color: var(--fg1);
+}
+
+.btn-outline-danger, .btn-danger {
+  background: var(--btn-light-bg); color: var(--danger); border-color: #B23A2E55;
+  box-shadow: var(--btn-light-sh);
+}
+.btn-outline-danger:hover, .btn-danger:hover { background: var(--danger-tint); color: var(--danger); }
+
+.btn-ghost {
+  background: transparent; color: var(--fg2); border-color: transparent; box-shadow: none;
+}
+.btn-ghost:hover { background: var(--paper-deep); color: var(--fg1); }
+
+.btn[disabled], .btn:disabled { opacity: 0.45; pointer-events: none; }
+
+/* Button groups */
+.mw-btn-group { display: inline-flex; align-items: center; gap: 10px; }
+.mw-btn-group--end { display: flex; justify-content: flex-end; }
+.mw-btn-group--attached { gap: 0; border: 1px solid var(--hairline-strong); border-radius: var(--r-sm); overflow: hidden; box-shadow: var(--btn-light-sh); }
+.mw-btn-group--attached .btn { border-radius: 0; border: 0; border-left: 1px solid var(--hairline-strong); box-shadow: none; }
+.mw-btn-group--attached .btn:first-child { border-left: 0; }
+.mw-btn-group--attached .btn.is-on { background: var(--orange-tint); color: var(--ink); }
+
+/* Form action footer */
+.mw-form-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 24px; padding-top: 18px; border-top: 1px solid var(--hairline); }
+.mw-form-actions form { display: inline-flex; }
+
+/* --- Forms --- */
+.mb-3.field, .form-field { margin-bottom: 18px; }
+form .mb-3 { margin-bottom: 18px; }
+
+.form-label {
+  display: inline-flex; gap: 3px; font-family: var(--sans); font-size: 12px; font-weight: 600;
+  color: var(--fg2); margin-bottom: 6px;
+}
+
+.form-control, .form-select,
+input[type="text"], input[type="email"], input[type="password"],
+input[type="search"], input[type="datetime-local"], input[type="number"],
+textarea, select {
+  width: 100%; box-sizing: border-box; font-family: var(--sans); font-size: 14px; color: var(--fg1);
+  padding: 9px 11px; border-radius: var(--r-sm); border: 1px solid var(--hairline-strong);
+  background: var(--input-bg); box-shadow: var(--input-sh); outline: none;
+  transition: all var(--dur-fast) var(--ease);
+}
+textarea { resize: vertical; }
+.form-control::placeholder, textarea::placeholder, input::placeholder { color: var(--fg3); }
+
+.form-control:focus, .form-select:focus,
+input:focus, textarea:focus, select:focus {
+  background: var(--card); border-color: var(--orange); box-shadow: var(--input-sh-focus);
+}
+
+/* Mono fields (slugs / metadata) */
+input.mono, .form-control.mono { font-family: var(--mono); font-size: 13px; }
+
+.form-control.is-invalid { border-color: var(--danger); }
+.invalid-feedback { color: var(--danger); font-size: 12.5px; margin-top: 5px; }
+.invalid-feedback.d-block { display: block; }
+
+select {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238C8478' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 11px center; padding-right: 32px;
+}
+
+/* Checkboxes */
+.form-check { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.form-check-input {
+  width: 17px; height: 17px; margin: 0; flex: none; cursor: pointer; appearance: none;
+  -webkit-appearance: none; border: 1px solid var(--hairline-strong); border-radius: var(--r-sm);
+  background: var(--input-bg); box-shadow: var(--input-sh); position: relative;
+  transition: all var(--dur-fast) var(--ease);
+}
+.form-check-input:checked { background: var(--btn-primary-bg); border-color: var(--orange-deep); box-shadow: var(--btn-primary-sh); }
+.form-check-input:checked::after {
+  content: ""; position: absolute; left: 5px; top: 2px; width: 4px; height: 8px;
+  border: solid #fff; border-width: 0 2px 2px 0; transform: rotate(45deg);
+}
+.form-check-input:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--orange-tint); }
+.form-check-label { font-size: 14px; color: var(--fg1); cursor: pointer; }
+
+/* input-group (inline action buttons) */
+.input-group { display: inline-flex; gap: 6px; align-items: center; }
+
+/* --- Cards --- */
+.card {
+  background: var(--card); border: 1px solid var(--hairline); border-radius: var(--r-md);
+  box-shadow: var(--card-raised); overflow: hidden;
+}
+.card-body { padding: 20px; }
+
+/* --- Tables --- */
+.table-responsive {
+  background: var(--card); border: 1px solid var(--hairline); border-radius: var(--r-md);
+  box-shadow: var(--card-raised); overflow: hidden;
+}
+.table { width: 100%; border-collapse: collapse; margin: 0; }
+.table thead th {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg3); text-align: left; font-weight: 400; padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--hairline);
+}
+.table tbody td {
+  padding: 16px; border-top: 1px solid var(--hairline); font-size: 14px;
+  vertical-align: middle; color: var(--fg1);
+}
+.table tbody tr:first-child td { border-top: none; }
+.table tbody tr { transition: background var(--dur-fast) var(--ease); }
+.table tbody tr:hover { background: var(--paper); }
+.table .col-actions, .table td.col-actions { text-align: right; white-space: nowrap; }
+.table .cell-mono { font-family: var(--mono); font-size: 12.5px; color: var(--fg2); }
+.table .cell-title { font-weight: 600; }
+.table .cell-sub { font-family: var(--mono); font-size: 12px; color: var(--fg3); margin-top: 3px; }
+.table th a { color: var(--fg3); text-decoration: none; }
+.table th a:hover { color: var(--orange-deep); }
+
+/* --- Flash banner --- */
+.mw-flash {
+  display: flex; align-items: center; gap: 10px; padding: 11px 16px; margin-bottom: 22px;
+  background: var(--ink); color: var(--fg-on-dark); border-radius: var(--r-md);
+  font-size: 13.5px; font-weight: 500;
+}
+.mw-flash .mw-icon { color: var(--orange); }
+.mw-flash--warning { background: var(--warning-tint); color: var(--warning); }
+.mw-flash--warning .mw-icon { color: var(--warning); }
+.mw-flash--danger { background: var(--danger-tint); color: var(--danger); }
+.mw-flash--danger .mw-icon { color: var(--danger); }
+.mw-flash--success .mw-icon { color: var(--success); }
+
+/* Bootstrap-named alerts (form error summary, etc.) */
+.alert {
+  padding: 12px 16px; margin-bottom: 18px; border-radius: var(--r-md);
+  border: 1px solid var(--hairline); font-size: 13.5px; background: var(--paper-deep); color: var(--fg1);
+}
+.alert-heading { font-family: var(--sans); font-weight: 600; font-size: 15px; margin: 0 0 6px; }
+.alert ul { margin: 0; padding-left: 18px; }
+.alert-danger { background: var(--danger-tint); border-color: #B23A2E33; color: var(--danger); }
+.alert-warning { background: var(--warning-tint); border-color: #B5791A33; color: var(--warning); }
+.alert-success { background: var(--success-tint); border-color: #3E7A4E33; color: var(--success); }
+.alert-info { background: var(--paper-deep); border-color: var(--hairline-strong); color: var(--fg1); }
+
+/* --- Status badge --- */
+.mw-badge {
+  font-size: 11px; font-weight: 600; padding: 3px 9px; border-radius: var(--r-sm);
+  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
+  background: var(--paper-deep); color: var(--fg2);
+}
+.mw-badge--published { background: var(--success-tint); color: var(--success); }
+.mw-badge--accent { background: var(--orange-tint); color: var(--orange-deep); }
+
+/* --- Tag pill --- */
+.mw-tag {
+  font-family: var(--mono); font-size: 12px; padding: 4px 11px; border-radius: var(--r-pill);
+  display: inline-flex; align-items: center; user-select: none; white-space: nowrap;
+  background: var(--card); color: var(--fg2); border: 1px solid var(--hairline-strong);
+}
+.mw-tag--active { background: var(--orange-tint); color: var(--orange-deep); border-color: #EC5A1E55; }
+.mw-tags { display: flex; gap: 5px; flex-wrap: wrap; }
+
+/* --- Pagination (pagy :bootstrap markup) --- */
+.pagination { display: inline-flex; gap: 6px; list-style: none; padding: 0; margin: 16px 0 0; }
+.pagination .page-item { display: inline-flex; }
+.pagination .page-link, .pagination a, .pagination span {
+  font-family: var(--mono); font-size: 13px; min-width: 34px; height: 34px; padding: 0 10px;
+  display: inline-flex; align-items: center; justify-content: center; border-radius: var(--r-sm);
+  border: 1px solid var(--hairline-strong); background: var(--btn-light-bg); color: var(--fg1);
+  box-shadow: var(--btn-light-sh); text-decoration: none; cursor: pointer;
+}
+.pagination .page-link:hover { background: var(--btn-light-bg-h); text-decoration: none; }
+.pagination .active .page-link, .pagination .page-item.active span {
+  background: var(--btn-primary-bg); border-color: var(--orange-deep); color: #fff; box-shadow: var(--btn-primary-sh);
+}
+.pagination .disabled .page-link, .pagination .page-item.disabled span {
+  opacity: 0.45; pointer-events: none; box-shadow: none;
+}
+
+/* --- Bento stat strip --- */
+.mw-stats {
+  display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--hairline);
+  border-radius: var(--r-md); box-shadow: var(--card-raised); overflow: hidden;
+  margin-bottom: 28px; background: var(--card);
+}
+.mw-stat { padding: 16px 18px; border-left: 1px solid var(--hairline); }
+.mw-stat:first-child { border-left: none; }
+.mw-stat__label { display: block; margin-bottom: 10px; }
+.mw-stat__value {
+  font-family: var(--mono); font-weight: 700; font-size: 34px; line-height: 1;
+  letter-spacing: -0.03em; color: var(--fg1); font-feature-settings: "tnum" 1;
+}
+.mw-stat__value--accent { color: var(--orange); }
+
+/* --- Icons --- */
+.mw-icon { display: inline-flex; align-items: center; justify-content: center; flex: none; }
+.mw-icon svg { width: 100%; height: 100%; display: block; stroke-width: 1.75; }
+.mw-icon--xs { width: var(--icon-xs); height: var(--icon-xs); }
+.mw-icon--sm { width: var(--icon-sm); height: var(--icon-sm); }
+.mw-icon--md { width: var(--icon-md); height: var(--icon-md); }
+.mw-icon--lg { width: var(--icon-lg); height: var(--icon-lg); }
+.mw-icon--xl { width: var(--icon-xl); height: var(--icon-xl); }
+
+/* --- Post editor (two-column) --- */
+.mw-editor { display: grid; grid-template-columns: 1fr 300px; gap: 28px; align-items: start; }
+.mw-editor__title {
+  width: 100%; box-sizing: border-box; border: none; outline: none; background: transparent;
+  font-family: var(--serif); font-weight: 500; font-size: 36px; letter-spacing: -0.01em;
+  color: var(--fg1); margin-bottom: 14px; padding: 0; box-shadow: none;
+}
+.mw-editor__title:focus { box-shadow: none; background: transparent; }
+.mw-editor__main .form-label { display: block; }
+.mw-editor__side { display: flex; flex-direction: column; gap: 18px; }
+.mw-panel {
+  background: var(--card); border: 1px solid var(--hairline); border-radius: var(--r-md);
+  box-shadow: var(--card-raised); padding: 18px;
+}
+.mw-panel__label { display: block; margin-bottom: 14px; }
+
+@media (max-width: 900px) {
+  .mw-editor { grid-template-columns: 1fr; }
+}
+
+/* ============================================================
+   6. PUBLIC (blog) SURFACE — light editorial styling
+   ============================================================ */
+.container { width: 100%; max-width: var(--content-max); margin: 0 auto; padding: 0 24px; }
+.container-fluid { width: 100%; }
+
+.bg-light { background: var(--paper); }
+.bg-dark { background: var(--ink); color: var(--fg-on-dark); }
+.text-white { color: var(--fg-on-dark) !important; }
+
+.navbar { display: flex; align-items: center; }
+.navbar-brand { font-family: var(--serif); font-weight: 500; font-size: 26px; color: var(--ink); }
+.navbar-brand:hover { text-decoration: none; }
+header.bg-light { border-bottom: 1px solid var(--hairline); background: var(--card); }
+.footer { border-top: 1px solid var(--hairline); color: var(--fg3); font-size: 13px; background: var(--card); }
+.footer .container { padding-top: 8px; padding-bottom: 8px; }
+
+/* ============================================================
+   7. QUILL editor theming
+   ============================================================ */
+.quill-editor-wrapper { border: 1px solid var(--hairline-strong); border-radius: var(--r-sm); background: var(--card); box-shadow: var(--card-raised); overflow: hidden; }
+.ql-toolbar.ql-snow { border: none; border-bottom: 1px solid var(--hairline); background: var(--paper); }
+.ql-container.ql-snow { border: none; font-family: var(--serif); font-size: 17px; }
+.ql-editor { min-height: 220px; line-height: 1.65; color: var(--fg1); }
+.ql-editor.ql-blank::before { color: var(--fg3); font-style: normal; }
+.ql-snow .ql-stroke { stroke: var(--fg2); }
+.ql-snow .ql-fill { fill: var(--fg2); }
+.ql-snow .ql-picker { color: var(--fg2); }
+.ql-snow.ql-toolbar button:hover .ql-stroke, .ql-snow .ql-toolbar button:hover .ql-stroke { stroke: var(--orange-deep); }
+.ql-snow.ql-toolbar button.ql-active .ql-stroke { stroke: var(--orange-deep); }

--- a/app/views/hyper_kitten_meow/components/button.rb
+++ b/app/views/hyper_kitten_meow/components/button.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::Button < Components::Base
+    include Phlex::Rails::Helpers::ButtonTo
+
+    VARIANTS = {
+      primary: "btn-primary",
+      secondary: "btn-secondary",
+      outline: "btn-outline",
+      ghost: "btn-ghost",
+      danger: "btn-danger"
+    }.freeze
+
+    def initialize(text = nil, to:, variant: :primary, size: :md, icon: nil, **options)
+      @text = text
+      @to = to
+      @variant = variant
+      @size = size
+      @icon = icon
+      @options = options
+    end
+
+    def view_template(&block)
+      attrs = mix({class: ["btn", VARIANTS.fetch(@variant, "btn-primary"), ("btn-sm" if @size == :sm)], form_class: "d-inline"}, @options)
+
+      button_to @to, **attrs do
+        render Components::Icon.new(@icon, size: (@size == :sm ? :sm : :lg)) if @icon
+        @text ? plain(@text) : yield
+      end
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/button_group.rb
+++ b/app/views/hyper_kitten_meow/components/button_group.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::ButtonGroup < Components::Base
+    def initialize(attached: false, align: nil, **options)
+      @attached = attached
+      @align = align
+      @options = options
+    end
+
+    def view_template(&block)
+      classes = [
+        "mw-btn-group",
+        ("mw-btn-group--attached" if @attached),
+        ("mw-btn-group--end" if @align == :end),
+        @options.delete(:class)
+      ].compact
+      div(class: classes, **@options, &block)
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/flash.rb
+++ b/app/views/hyper_kitten_meow/components/flash.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::Flash < Components::Base
+    KINDS = {
+      "alert" => "warning",
+      "error" => "danger",
+      "notice" => "info",
+      "success" => "success"
+    }.freeze
+
+    def initialize(flash:)
+      @flash = flash
+    end
+
+    def view_template
+      messages.each do |key, value|
+        kind = KINDS[key]
+        div(class: "mw-flash mw-flash--#{kind}") do
+          render Components::Icon.new(icon_for(kind), size: :sm)
+          span { value }
+        end
+      end
+    end
+
+    private
+
+    def messages
+      @flash.to_hash.slice(*KINDS.keys)
+    end
+
+    def icon_for(kind)
+      (kind == "danger" || kind == "warning") ? "alert-triangle" : "check-circle-2"
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/icon.rb
+++ b/app/views/hyper_kitten_meow/components/icon.rb
@@ -12,6 +12,8 @@ module HyperKittenMeow
     end
 
     def view_template
+      return unless @name.match?(/\A[a-z0-9-]+\z/)
+
       path = ICON_DIR.join("#{@name}.svg")
       return unless path.file?
 

--- a/app/views/hyper_kitten_meow/components/icon.rb
+++ b/app/views/hyper_kitten_meow/components/icon.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::Icon < Components::Base
+    SIZES = %i[xs sm md lg xl].freeze
+    ICON_DIR = HyperKittenMeow::Engine.root.join("app/assets/images/hyper_kitten_meow/icons")
+
+    def initialize(name, size: :md, **options)
+      @name = name.to_s
+      @size = size
+      @options = options
+    end
+
+    def view_template
+      path = ICON_DIR.join("#{@name}.svg")
+      return unless path.file?
+
+      classes = ["mw-icon", size_class, @options.delete(:class)].compact
+      span(class: classes, style: inline_size, **@options) do
+        raw(safe(path.read.sub(/\A<!--.*?-->\s*/m, "").strip))
+      end
+    end
+
+    private
+
+    def size_class
+      "mw-icon--#{@size}" if SIZES.include?(@size)
+    end
+
+    def inline_size
+      {width: "#{@size}px", height: "#{@size}px"} unless SIZES.include?(@size)
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/link_button.rb
+++ b/app/views/hyper_kitten_meow/components/link_button.rb
@@ -11,21 +11,34 @@ module HyperKittenMeow
       outline_secondary: "btn btn-outline-secondary",
       outline_info: "btn btn-outline-info",
       outline_danger: "btn btn-outline-danger",
+      ghost: "btn btn-ghost",
       sm_outline_info: "btn btn-sm btn-outline-info",
-      sm_outline_danger: "btn btn-sm btn-outline-danger"
-    }
+      sm_outline_danger: "btn btn-sm btn-outline-danger",
+      sm_ghost: "btn btn-sm btn-ghost"
+    }.freeze
 
-    def initialize(path, text, scheme: :primary, **options)
+    def initialize(path, text, scheme: :primary, icon: nil, **options)
       @path = path
       @text = text
       @scheme = scheme
+      @icon = icon
       @options = options
     end
 
     def view_template
       css_class = SCHEMES.fetch(@scheme, SCHEMES[:primary])
       css_class = "#{css_class} #{@options.delete(:class)}" if @options[:class]
-      link_to @text, @path, class: css_class, **@options
+
+      link_to @path, class: css_class, **@options do
+        render Components::Icon.new(@icon, size: icon_size) if @icon
+        plain @text
+      end
+    end
+
+    private
+
+    def icon_size
+      @scheme.to_s.start_with?("sm_") ? :sm : :lg
     end
   end
 end

--- a/app/views/hyper_kitten_meow/components/page_header.rb
+++ b/app/views/hyper_kitten_meow/components/page_header.rb
@@ -2,14 +2,18 @@
 
 module HyperKittenMeow
   class Components::PageHeader < Components::Base
-    def initialize(title:)
+    def initialize(title:, eyebrow: nil)
       @title = title
+      @eyebrow = eyebrow
     end
 
     def view_template(&block)
-      div(class: "d-flex justify-content-between align-items-center mb-4") do
-        h2 { @title }
-        div(class: "action", &block) if block_given?
+      div(class: "mw-pageheader") do
+        div do
+          span(class: "ds-eyebrow mw-pageheader__eyebrow") { @eyebrow } if @eyebrow
+          h1 { @title }
+        end
+        div(class: "mw-pageheader__actions", &block) if block_given?
       end
     end
   end

--- a/app/views/hyper_kitten_meow/components/sidebar.rb
+++ b/app/views/hyper_kitten_meow/components/sidebar.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::Sidebar < Components::Base
+    include Phlex::Rails::Helpers::LinkTo
+    include Phlex::Rails::Helpers::Request
+
+    def initialize(light: true)
+      @light = light
+    end
+
+    def view_template(&block)
+      nav(class: "mw-sidebar") do
+        div(class: "mw-sidebar__brand") { render Components::Wordmark.new(light: @light) }
+        yield(self) if block_given?
+      end
+    end
+
+    def section(title)
+      span(class: "ds-eyebrow mw-sidebar__section") { title }
+    end
+
+    def menu(&block)
+      div(class: "mw-nav", &block)
+    end
+
+    def item(label, path, icon:, active: nil)
+      active = request.path.start_with?(path) if active.nil?
+      classes = ["mw-nav__item", ("is-active" if active)].compact
+      link_to path, class: classes do
+        render Components::Icon.new(icon, size: :md)
+        plain label
+      end
+    end
+
+    def user_chip(name:, logout_path:, role: "Admin", logout_title: "Log Out")
+      div(class: "mw-sidebar__foot") do
+        div(class: "mw-userchip") do
+          div(class: "mw-userchip__avatar") { initials(name) }
+          div(class: "mw-userchip__meta") do
+            div(class: "mw-userchip__name") { name }
+            div(class: "mw-userchip__role") { role }
+          end
+          link_to logout_path, class: "mw-userchip__logout", title: logout_title do
+            render Components::Icon.new("log-out", size: :sm)
+          end
+        end
+      end
+    end
+
+    private
+
+    def initials(name)
+      name.to_s.split.map(&:first).join.upcase
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/status_badge.rb
+++ b/app/views/hyper_kitten_meow/components/status_badge.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::StatusBadge < Components::Base
+    def initialize(published:)
+      @published = published
+    end
+
+    def view_template
+      if @published
+        span(class: "mw-badge mw-badge--published") { "● Published" }
+      else
+        span(class: "mw-badge") { "○ Draft" }
+      end
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/tag.rb
+++ b/app/views/hyper_kitten_meow/components/tag.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::Tag < Components::Base
+    def initialize(label, active: false)
+      @label = label
+      @active = active
+    end
+
+    def view_template
+      span(class: ["mw-tag", ("mw-tag--active" if @active)].compact) { @label }
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/components/wordmark.rb
+++ b/app/views/hyper_kitten_meow/components/wordmark.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module HyperKittenMeow
+  class Components::Wordmark < Components::Base
+    include Phlex::Rails::Helpers::AssetPath
+
+    def initialize(light: false, mark_only: false)
+      @light = light
+      @mark_only = mark_only
+    end
+
+    def view_template
+      mark = @light ? "hyper_kitten_meow/meow-mark-light.svg" : "hyper_kitten_meow/meow-mark.svg"
+      span(class: ["mw-wordmark", ("mw-wordmark--light" if @light)]) do
+        img(src: asset_path(mark), alt: "Meow")
+        unless @mark_only
+          span(class: "mw-wordmark__text") do
+            plain "Meow"
+            span(class: "dot") { "." }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/hyper_kitten_meow/views/admin/base.rb
+++ b/app/views/hyper_kitten_meow/views/admin/base.rb
@@ -7,75 +7,55 @@ module HyperKittenMeow
     register_value_helper :logged_in?
     register_value_helper :current_user
 
-    KEY_TRANSFORMATIONS = {
-      "alert" => "warning",
-      "error" => "danger",
-      "notice" => "info",
-      "success" => "success"
-    }
-
     def page_title
       "#{t('title')} - Admin"
     end
 
+    def render_chrome?
+      true
+    end
+
     def head_content
       stylesheet_link_tag "https://cdn.quilljs.com/1.3.6/quill.snow.css"
-      stylesheet_link_tag "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css"
       javascript_importmap_tags("hyper_kitten_meow/application")
     end
 
     def around_template(&block)
       super do
-        div(class: "container-fluid h-100") do
-          div(class: "row h-100") do
+        if render_chrome?
+          div(class: "mw-shell") do
             render_sidebar
-            div(class: "col-md-9 col-lg-10 mt-3 px-4") do
-              render_flash
-              yield
+            div(class: "mw-content") do
+              div(class: "mw-content__inner") do
+                render Components::Flash.new(flash: flash)
+                yield
+              end
             end
           end
+        else
+          yield
         end
       end
     end
 
     private
 
-    def render_flash
-      return unless flash.any?
-
-      flashes = flash.to_hash.slice("alert", "error", "notice", "success")
-      user_flashes = flashes.transform_keys { |key| KEY_TRANSFORMATIONS[key] }
-      user_flashes.each do |key, value|
-        div(class: "alert alert-#{key}") { value }
-      end
-    end
-
     def render_sidebar
-      nav(class: "col-md-3 col-lg-2 d-md-block sidebar bg-dark text-white d-flex flex-column") do
-        h3(class: "mb-3 mt-3") { t("title") }
-        hr
-        if logged_in?
-          ul(class: "nav nav-pills flex-column mb-auto") do
-            li(class: "nav-item") { link_to "Posts", hyper_kitten_meow.admin_posts_path, class: "nav-link text-white" }
-            li(class: "nav-item") { link_to "Pages", hyper_kitten_meow.admin_pages_path, class: "nav-link text-white" }
-            li(class: "nav-item") { link_to "Tags", hyper_kitten_meow.admin_tags_path, class: "nav-link text-white" }
-            li(class: "nav-item") { link_to "Users", hyper_kitten_meow.admin_users_path, class: "nav-link text-white" }
-          end
-          hr
-          render_user_menu
-        end
-      end
-    end
+      render Components::Sidebar.new do |s|
+        next unless logged_in?
 
-    def render_user_menu
-      link_to "#",
-        class: "nav-link d-flex align-items-center text-white text-decoration-none dropdown-toggle",
-        data: {bs_toggle: "dropdown"},
-        aria_expanded: false do
-        strong { current_user.name }
-      end
-      ul(class: "dropdown-menu dropdown-menu-dark text-small shadow") do
-        li { link_to t("sessions.destroy"), hyper_kitten_meow.admin_logout_path, class: "dropdown-item" }
+        s.section "Manage"
+        s.menu do
+          s.item "Posts", hyper_kitten_meow.admin_posts_path, icon: "newspaper"
+          s.item "Pages", hyper_kitten_meow.admin_pages_path, icon: "file-text"
+          s.item "Tags",  hyper_kitten_meow.admin_tags_path,  icon: "tag"
+          s.item "Users", hyper_kitten_meow.admin_users_path, icon: "users"
+        end
+        s.user_chip(
+          name: current_user.name,
+          logout_path: hyper_kitten_meow.admin_logout_path,
+          logout_title: t("sessions.destroy")
+        )
       end
     end
   end

--- a/app/views/hyper_kitten_meow/views/admin/first_users/new.rb
+++ b/app/views/hyper_kitten_meow/views/admin/first_users/new.rb
@@ -6,18 +6,29 @@ module HyperKittenMeow
       @user = user
     end
 
+    def render_chrome?
+      false
+    end
+
     def view_template
-      section(class: "new-user") do
-        h2 { "Welcome to #{t('hyper_kitten_meow.title')}" }
-        p { "Please create your first user account to get started." }
+      div(class: "mw-setup") do
+        div(class: "mw-setup__inner") do
+          div(class: "mw-setup__brand") { render Components::Wordmark.new }
 
-        render Components::Form.new(model: @user, url: hyper_kitten_meow.admin_first_users_path, method: :post) do |f|
-          f.text_field :name, required: true
-          f.email_field :email, required: true
-          f.password_field :password, required: true
-          f.password_field :password_confirmation, required: true
+          div(class: "mw-setup__card new-user") do
+            span(class: "ds-eyebrow") { "First run" }
+            h2(class: "ds-h2") { "Create your account" }
+            p(class: "mw-setup__lede") { "Set up the first admin user to get started." }
 
-          f.submit
+            render Components::Form.new(model: @user, url: hyper_kitten_meow.admin_first_users_path, method: :post) do |f|
+              f.text_field :name, required: true
+              f.email_field :email, required: true
+              f.password_field :password, required: true
+              f.password_field :password_confirmation, required: true
+
+              f.submit
+            end
+          end
         end
       end
     end

--- a/app/views/hyper_kitten_meow/views/admin/pages/concerns/page_form.rb
+++ b/app/views/hyper_kitten_meow/views/admin/pages/concerns/page_form.rb
@@ -27,8 +27,8 @@ module HyperKittenMeow
 
           f.check_box :published
 
-          div(class: "d-flex justify-content-between mt-4") do
-            render Components::LinkButton.new(cancel_path, "Cancel", scheme: :secondary)
+          div(class: "mw-form-actions") do
+            render Components::LinkButton.new(cancel_path, "Cancel", scheme: :ghost)
             f.submit
           end
         end

--- a/app/views/hyper_kitten_meow/views/admin/pages/edit.rb
+++ b/app/views/hyper_kitten_meow/views/admin/pages/edit.rb
@@ -12,7 +12,7 @@ module HyperKittenMeow
     def view_template
       section(class: "edit-page") do
         render Components::PageHeader.new(title: "Editing Page: #{@page.title}") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_pages_path, "Back to Pages", scheme: :secondary)
+          render Components::LinkButton.new(hyper_kitten_meow.admin_pages_path, "Back to Pages", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_page_form(

--- a/app/views/hyper_kitten_meow/views/admin/pages/index.rb
+++ b/app/views/hyper_kitten_meow/views/admin/pages/index.rb
@@ -9,18 +9,19 @@ module HyperKittenMeow
 
     def view_template
       section(class: "pages") do
-        render Components::PageHeader.new(title: "Pages") do
-          render Components::LinkButton.new(hyper_kitten_meow.new_admin_page_path, "Add New")
+        render Components::PageHeader.new(title: "Pages", eyebrow: "#{@pagy.count} static pages") do
+          render Components::LinkButton.new(hyper_kitten_meow.new_admin_page_path, "Add New", icon: "plus")
         end
 
         render Components::Table.new(collection: @pages, tr: {class: "page"}) do |t|
-          t.column "Title", method_name: :title
-          t.column "Slug", method_name: :slug
-          t.column "Actions" do |page|
+          t.column "Title", class: "cell-title", method_name: :title
+          t.column "Slug", class: "cell-mono", method_name: :slug
+          t.column "", header_options: {class: "col-actions"}, class: "col-actions" do |page|
             render Components::LinkButton.new(
               hyper_kitten_meow.edit_admin_page_path(page),
               "Edit",
-              scheme: :sm_outline_info
+              scheme: :sm_outline_info,
+              icon: "pen-line"
             )
           end
           t.footer do

--- a/app/views/hyper_kitten_meow/views/admin/pages/new.rb
+++ b/app/views/hyper_kitten_meow/views/admin/pages/new.rb
@@ -12,7 +12,7 @@ module HyperKittenMeow
     def view_template
       section do
         render Components::PageHeader.new(title: "New Page") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_pages_path, "Back to Pages", scheme: :secondary)
+          render Components::LinkButton.new(hyper_kitten_meow.admin_pages_path, "Back to Pages", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_page_form(

--- a/app/views/hyper_kitten_meow/views/admin/posts/concerns/post_form.rb
+++ b/app/views/hyper_kitten_meow/views/admin/posts/concerns/post_form.rb
@@ -15,8 +15,8 @@ module HyperKittenMeow
 
         f.check_box :published
 
-        div(class: "d-flex justify-content-between mt-4") do
-          render Components::LinkButton.new(cancel_path, "Cancel", scheme: :secondary)
+        div(class: "mw-form-actions") do
+          render Components::LinkButton.new(cancel_path, "Cancel", scheme: :ghost)
           f.submit
         end
       end

--- a/app/views/hyper_kitten_meow/views/admin/posts/edit.rb
+++ b/app/views/hyper_kitten_meow/views/admin/posts/edit.rb
@@ -10,8 +10,8 @@ module HyperKittenMeow
 
     def view_template
       section(class: "edit-post") do
-        render Components::PageHeader.new(title: "Editing Post: #{@post.title}") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_posts_path, "Back to Posts", scheme: :secondary)
+        render Components::PageHeader.new(title: "Edit Post", eyebrow: "Editing") do
+          render Components::LinkButton.new(hyper_kitten_meow.admin_posts_path, "Back to Posts", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_post_form(

--- a/app/views/hyper_kitten_meow/views/admin/posts/index.rb
+++ b/app/views/hyper_kitten_meow/views/admin/posts/index.rb
@@ -2,9 +2,10 @@
 
 module HyperKittenMeow
   class Views::Admin::Posts::Index < Views::Admin::Base
-    def initialize(posts:, pagy:)
+    def initialize(posts:, pagy:, published_count:)
       @posts = posts
       @pagy = pagy
+      @published_count = published_count
     end
 
     def view_template
@@ -50,7 +51,7 @@ module HyperKittenMeow
     private
 
     def posts_eyebrow
-      "#{@pagy.count} total · #{Post.published.count} published"
+      "#{@pagy.count} total · #{@published_count} published"
     end
   end
 end

--- a/app/views/hyper_kitten_meow/views/admin/posts/index.rb
+++ b/app/views/hyper_kitten_meow/views/admin/posts/index.rb
@@ -9,27 +9,35 @@ module HyperKittenMeow
 
     def view_template
       section(class: "posts") do
-        render Components::PageHeader.new(title: "Posts") do
-          render Components::LinkButton.new(hyper_kitten_meow.new_admin_post_path, "Add New")
+        render Components::PageHeader.new(title: "Posts", eyebrow: posts_eyebrow) do
+          render Components::LinkButton.new(hyper_kitten_meow.new_admin_post_path, "Add New", icon: "plus")
         end
 
         render Components::Table.new(collection: @posts, tr: {class: "post"}) do |t|
-          t.column "Title", method_name: :title
-          t.column "Article" do |post|
-            post.summary.to_s.truncate(40, separator: " ")
+          t.column "Title" do |post|
+            div(class: "cell-title") { post.title }
+            div(class: "cell-sub") { post.slug }
           end
           t.column "Author" do |post|
             post.user.name
           end
-          t.column "Slug", method_name: :slug
           t.column "Tags" do |post|
-            post.tags.to_a.to_sentence
+            div(class: "mw-tags") do
+              post.tags.to_a.each { |tag| render Components::Tag.new(tag.label) }
+            end
           end
-          t.column "Actions" do |post|
+          t.column "Status" do |post|
+            render Components::StatusBadge.new(published: post.published?)
+          end
+          t.column "Date", class: "cell-mono" do |post|
+            post.published_at&.strftime("%m/%d/%Y") || "—"
+          end
+          t.column "", header_options: {class: "col-actions"}, class: "col-actions" do |post|
             render Components::LinkButton.new(
               hyper_kitten_meow.edit_admin_post_path(post),
               "Edit",
-              scheme: :sm_outline_info
+              scheme: :sm_outline_info,
+              icon: "pen-line"
             )
           end
           t.footer do
@@ -37,6 +45,12 @@ module HyperKittenMeow
           end
         end
       end
+    end
+
+    private
+
+    def posts_eyebrow
+      "#{@pagy.count} total · #{Post.published.count} published"
     end
   end
 end

--- a/app/views/hyper_kitten_meow/views/admin/posts/new.rb
+++ b/app/views/hyper_kitten_meow/views/admin/posts/new.rb
@@ -10,8 +10,8 @@ module HyperKittenMeow
 
     def view_template
       section do
-        render Components::PageHeader.new(title: "New Post") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_posts_path, "Back to Posts", scheme: :secondary)
+        render Components::PageHeader.new(title: "New Post", eyebrow: "Draft") do
+          render Components::LinkButton.new(hyper_kitten_meow.admin_posts_path, "Back to Posts", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_post_form(

--- a/app/views/hyper_kitten_meow/views/admin/sessions/new.rb
+++ b/app/views/hyper_kitten_meow/views/admin/sessions/new.rb
@@ -2,16 +2,63 @@
 
 module HyperKittenMeow
   class Views::Admin::Sessions::New < Views::Admin::Base
+    include Phlex::Rails::Helpers::AssetPath
+
+    def render_chrome?
+      false
+    end
+
     def view_template
-      section(class: "d-flex justify-content-center") do
-        div(style: "width: 300px;") do
-          h2(class: "mb-4") { "Login" }
+      div(class: "mw-login") do
+        render_aside
+        render_form
+      end
+    end
+
+    private
+
+    def render_aside
+      div(class: "mw-login__aside") do
+        render Components::Wordmark.new(light: true)
+
+        div do
+          span(class: "ds-eyebrow") { "Open-source blogging engine" }
+          h1(class: "mw-login__headline") do
+            plain "A deliberately "
+            em { "boring" }
+            plain " place to write."
+          end
+          p(class: "mw-login__lede") do
+            "Posts, pages, tags. No frills, no ceremony — just a fast, readable admin for your Rails blog."
+          end
+        end
+
+        div(class: "mw-login__footmark") { "=^··^=  HYPER-KITTEN / MEOW" }
+
+        img(
+          src: asset_path("hyper_kitten_meow/meow-mark-light.svg"),
+          alt: "",
+          aria_hidden: "true",
+          class: "mw-login__ghost"
+        )
+      end
+    end
+
+    def render_form
+      div(class: "mw-login__main") do
+        div(class: "mw-login__form") do
+          span(class: "ds-eyebrow") { "Admin" }
+          h2(class: "ds-h2") { "Sign in to continue" }
+
+          render Components::Flash.new(flash: flash)
 
           render Components::Form.new(url: hyper_kitten_meow.admin_login_path, scope: :session, method: :post) do |f|
-            f.email_field :email, required: true
-            f.password_field :password, required: true
+            f.email_field :email, label: "Email", required: true
+            f.password_field :password, label: "Password", required: true
             f.submit t("sessions.submit")
           end
+
+          div(class: "mw-login__hint") { "rails hyper_kitten:meow:create_user" }
         end
       end
     end

--- a/app/views/hyper_kitten_meow/views/admin/tags/concerns/tag_form.rb
+++ b/app/views/hyper_kitten_meow/views/admin/tags/concerns/tag_form.rb
@@ -6,8 +6,8 @@ module HyperKittenMeow
       render Components::Form.new(model: tag, url: url, method: method) do |f|
         f.text_field :label, required: true
 
-        div(class: "d-flex justify-content-between mt-4") do
-          render Components::LinkButton.new(cancel_path, "Cancel", scheme: :secondary)
+        div(class: "mw-form-actions") do
+          render Components::LinkButton.new(cancel_path, "Cancel", scheme: :ghost)
           f.submit
         end
       end

--- a/app/views/hyper_kitten_meow/views/admin/tags/edit.rb
+++ b/app/views/hyper_kitten_meow/views/admin/tags/edit.rb
@@ -11,7 +11,7 @@ module HyperKittenMeow
     def view_template
       section do
         render Components::PageHeader.new(title: "Edit Tag") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_tags_path, "Back to Tags", scheme: :secondary)
+          render Components::LinkButton.new(hyper_kitten_meow.admin_tags_path, "Back to Tags", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_tag_form(

--- a/app/views/hyper_kitten_meow/views/admin/tags/index.rb
+++ b/app/views/hyper_kitten_meow/views/admin/tags/index.rb
@@ -2,8 +2,6 @@
 
 module HyperKittenMeow
   class Views::Admin::Tags::Index < Views::Admin::Base
-    include Phlex::Rails::Helpers::ButtonTo
-
     def initialize(tags:, pagy:)
       @tags = tags
       @pagy = pagy
@@ -11,24 +9,30 @@ module HyperKittenMeow
 
     def view_template
       section(class: "tags") do
-        render Components::PageHeader.new(title: "Tags") do
-          render Components::LinkButton.new(hyper_kitten_meow.new_admin_tag_path, "Add New")
+        render Components::PageHeader.new(title: "Tags", eyebrow: "#{@pagy.count} in use") do
+          render Components::LinkButton.new(hyper_kitten_meow.new_admin_tag_path, "Add New", icon: "plus")
         end
 
         render Components::Table.new(collection: @tags) do |t|
-          t.column "Label", method_name: :label
-          t.column "Actions" do |tag|
-            div(class: "input-group") do
+          t.column "Label" do |tag|
+            render Components::Tag.new(tag.label, active: true)
+          end
+          t.column "", header_options: {class: "col-actions"}, class: "col-actions" do |tag|
+            render Components::ButtonGroup.new(align: :end) do
               render Components::LinkButton.new(
                 hyper_kitten_meow.edit_admin_tag_path(tag),
                 "Edit",
-                scheme: :sm_outline_info
+                scheme: :sm_outline_info,
+                icon: "pen-line"
               )
-              button_to "Delete",
-                hyper_kitten_meow.admin_tag_path(tag),
+              render Components::Button.new(
+                "Delete",
+                to: hyper_kitten_meow.admin_tag_path(tag),
                 method: :delete,
-                class: "btn btn-sm btn-outline-danger",
-                form_class: "d-inline"
+                variant: :danger,
+                size: :sm,
+                icon: "trash-2"
+              )
             end
           end
           t.footer do

--- a/app/views/hyper_kitten_meow/views/admin/tags/new.rb
+++ b/app/views/hyper_kitten_meow/views/admin/tags/new.rb
@@ -11,7 +11,7 @@ module HyperKittenMeow
     def view_template
       section(class: "tags") do
         render Components::PageHeader.new(title: "New Tag") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_tags_path, "Back to Tags", scheme: :secondary)
+          render Components::LinkButton.new(hyper_kitten_meow.admin_tags_path, "Back to Tags", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_tag_form(

--- a/app/views/hyper_kitten_meow/views/admin/users/concerns/user_form.rb
+++ b/app/views/hyper_kitten_meow/views/admin/users/concerns/user_form.rb
@@ -9,8 +9,8 @@ module HyperKittenMeow
         f.password_field :password
         f.password_field :password_confirmation
 
-        div(class: "d-flex justify-content-between mt-4") do
-          render Components::LinkButton.new(cancel_path, "Cancel", scheme: :secondary)
+        div(class: "mw-form-actions") do
+          render Components::LinkButton.new(cancel_path, "Cancel", scheme: :ghost)
           f.submit
         end
       end

--- a/app/views/hyper_kitten_meow/views/admin/users/edit.rb
+++ b/app/views/hyper_kitten_meow/views/admin/users/edit.rb
@@ -11,7 +11,7 @@ module HyperKittenMeow
     def view_template
       section do
         render Components::PageHeader.new(title: "Editing User: #{@user.name}") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_users_path, "Back to Users", scheme: :secondary)
+          render Components::LinkButton.new(hyper_kitten_meow.admin_users_path, "Back to Users", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_user_form(

--- a/app/views/hyper_kitten_meow/views/admin/users/index.rb
+++ b/app/views/hyper_kitten_meow/views/admin/users/index.rb
@@ -2,8 +2,6 @@
 
 module HyperKittenMeow
   class Views::Admin::Users::Index < Views::Admin::Base
-    include Phlex::Rails::Helpers::ButtonTo
-
     def initialize(users:, pagy:)
       @users = users
       @pagy = pagy
@@ -11,24 +9,30 @@ module HyperKittenMeow
 
     def view_template
       section(class: "users") do
-        render Components::PageHeader.new(title: "Users") do
-          render Components::LinkButton.new(hyper_kitten_meow.new_admin_user_path, "Add New")
+        render Components::PageHeader.new(title: "Users", eyebrow: "#{@pagy.count} accounts") do
+          render Components::LinkButton.new(hyper_kitten_meow.new_admin_user_path, "Add New", icon: "plus")
         end
 
         render Components::Table.new(collection: @users, tr: {class: "user"}) do |t|
-          t.column "Name", method_name: :name
-          t.column "Email", method_name: :email
-          t.column "Manage" do |user|
-            render Components::LinkButton.new(
-              hyper_kitten_meow.edit_admin_user_path(user),
-              "Edit",
-              scheme: :sm_outline_info
-            )
-            button_to "Delete",
-              hyper_kitten_meow.admin_user_path(user),
-              method: :delete,
-              class: "btn btn-sm btn-outline-danger",
-              form_class: "d-inline"
+          t.column "Name", class: "cell-title", method_name: :name
+          t.column "Email", class: "cell-mono", method_name: :email
+          t.column "", header_options: {class: "col-actions"}, class: "col-actions" do |user|
+            render Components::ButtonGroup.new(align: :end) do
+              render Components::LinkButton.new(
+                hyper_kitten_meow.edit_admin_user_path(user),
+                "Edit",
+                scheme: :sm_outline_info,
+                icon: "pen-line"
+              )
+              render Components::Button.new(
+                "Delete",
+                to: hyper_kitten_meow.admin_user_path(user),
+                method: :delete,
+                variant: :danger,
+                size: :sm,
+                icon: "trash-2"
+              )
+            end
           end
           t.footer do
             render Components::Pagination.new(pagy: @pagy)

--- a/app/views/hyper_kitten_meow/views/admin/users/new.rb
+++ b/app/views/hyper_kitten_meow/views/admin/users/new.rb
@@ -11,7 +11,7 @@ module HyperKittenMeow
     def view_template
       section(class: "new-user") do
         render Components::PageHeader.new(title: "New User") do
-          render Components::LinkButton.new(hyper_kitten_meow.admin_users_path, "Back to Users", scheme: :secondary)
+          render Components::LinkButton.new(hyper_kitten_meow.admin_users_path, "Back to Users", scheme: :outline_secondary, icon: "arrow-left")
         end
 
         render_user_form(

--- a/app/views/hyper_kitten_meow/views/base.rb
+++ b/app/views/hyper_kitten_meow/views/base.rb
@@ -39,11 +39,9 @@ module HyperKittenMeow
 
         csrf_meta_tags
 
-        head_content
+        stylesheet_link_tag "hyper_kitten_meow/meow"
 
-        stylesheet_link_tag "https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css",
-          integrity: "sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3",
-          crossorigin: "anonymous"
+        head_content
       end
     end
   end

--- a/app/views/hyper_kitten_meow/views/base.rb
+++ b/app/views/hyper_kitten_meow/views/base.rb
@@ -39,9 +39,9 @@ module HyperKittenMeow
 
         csrf_meta_tags
 
-        stylesheet_link_tag "hyper_kitten_meow/meow"
-
         head_content
+
+        stylesheet_link_tag "hyper_kitten_meow/meow"
       end
     end
   end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,5 +1,3 @@
-pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.2/dist/js/bootstrap.esm.js"
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js"
 pin "@hotwired/turbo-rails", to: "https://ga.jspm.io/npm:@hotwired/turbo-rails@8.0.20/app/javascript/turbo/index.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true

--- a/lib/hyper_kitten_meow/concerns/controllers/admin/posts_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/posts_controller.rb
@@ -7,7 +7,7 @@ module HyperKittenMeow
 
           def index
             @pagy, @posts = pagy(Post.sorted_by_published_date)
-            render Views::Admin::Posts::Index.new(posts: @posts, pagy: @pagy)
+            render Views::Admin::Posts::Index.new(posts: @posts, pagy: @pagy, published_count: Post.published.count)
           end
 
           def new

--- a/lib/hyper_kitten_meow/engine.rb
+++ b/lib/hyper_kitten_meow/engine.rb
@@ -13,8 +13,16 @@ module HyperKittenMeow
       app.config.importmap.cache_sweepers << root.join("app/assets/javascripts")
     end
 
-    initializer "hyper-kitten-meow.assets.precompile" do |app|
-      app.config.assets.precompile += %w[hyper_kitten_meow/application.js]
+    initializer "hyper-kitten-meow.assets" do |app|
+      app.config.assets.paths << root.join("app/assets/stylesheets")
+      app.config.assets.paths << root.join("app/assets/images")
+      app.config.assets.precompile += %w[
+        hyper_kitten_meow/application.js
+        hyper_kitten_meow/meow.css
+        hyper_kitten_meow/meow-mark.svg
+        hyper_kitten_meow/meow-mark-light.svg
+        hyper_kitten_meow/meow-mark-orange.svg
+      ]
     end
 
     config.generators do |g|

--- a/spec/features/admin/posts/edit_spec.rb
+++ b/spec/features/admin/posts/edit_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Admin posts edit", type: :feature do
 
     visit hyper_kitten_meow.edit_admin_post_path(post)
 
-    expect(page).to have_text("My Title")
+    expect(page).to have_field("Title", with: "My Title")
 
     fill_in "Title", with: "Hello World!"
     fill_in "Summary", with: "My great summary!"
@@ -30,13 +30,12 @@ RSpec.feature "Admin posts edit", type: :feature do
     click_on "Update Post"
 
     expect(page).to have_text("Hello World!")
-    expect(page).to have_text("My great summary!")
     expect(page).to have_text("my-slug")
-    expect(page).to have_text("Josh")
     expect(page).to have_text("Josh")
     expect(page).to have_text("coffee")
 
     post = HyperKittenMeow::Post.last
     expect(post.body.to_plain_text).to eq("Fuzzy waffle!")
+    expect(post.summary).to eq("My great summary!")
   end
 end

--- a/spec/features/admin/posts/new_spec.rb
+++ b/spec/features/admin/posts/new_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature "Admin posts new", type: :feature do
     click_on "Create Post"
 
     expect(page).to have_text("Hello World!")
-    expect(page).to have_text("My great summary!")
     expect(page).to have_text("my-slug")
     expect(page).to have_text("Josh")
     expect(page).to have_text("coffee")
@@ -25,6 +24,7 @@ RSpec.feature "Admin posts new", type: :feature do
 
     post = HyperKittenMeow::Post.last
     expect(post.body.to_plain_text).to eq("Fuzzy waffle!")
+    expect(post.summary).to eq("My great summary!")
   end
 
   scenario "user can fix invalid posts" do


### PR DESCRIPTION
Move the admin backend off Bootstrap 5 (CDN CSS + JS) onto a custom, plain-CSS editorial theme: warm ink/cream monochrome with a single signal-orange accent, Newsreader / IBM Plex Sans / IBM Plex Mono, and restrained depth. Implements the Meow design system for the admin.

- Add app/assets/stylesheets/hyper_kitten_meow/meow.css: design tokens (color, type, spacing, radius, shadow, motion, icon + control sizing) plus a from-scratch implementation of the component/utility classes the markup uses, so the Bootstrap CDN, Bootstrap JS, Popper, and the bootstrap-icons font are all dropped.
- Vendor Lucide glyphs as SVGs and inline them server-side via a new Icon component (no CDN, no JS; currentColor keeps recoloring).
- New components: Sidebar (slotted), Flash, Button (wraps button_to), ButtonGroup, StatusBadge, Tag, Wordmark. Restyle PageHeader and LinkButton (icon support).
- Editorial split-screen login and first-run setup (no sidebar chrome).
- Enrich list screens (mono slugs, tag pills, status badges, icon buttons) and give forms a right-aligned action footer.
- Wire engine asset paths/precompile for the new stylesheet + images.

Editor header is now "Edit Post"/"Editing" and the posts index drops the free-text summary column (per the design); the two specs that asserted that old presentation now check the title field value and the persisted summary instead — behaviour is unchanged and now DB-verified.

Full suite: 79 examples, 0 failures.