### PR TITLE
Drop unused acts_as_list dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     hyper-kitten-meow (0.1.4)
-      acts_as_list
       bcrypt
       categorical
       human_urls (~> 0.1.7.pre.alpha.0)
@@ -95,9 +94,6 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    acts_as_list (1.2.6)
-      activerecord (>= 6.1)
-      activesupport (>= 6.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)

--- a/hyper-kitten-meow.gemspec
+++ b/hyper-kitten-meow.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tzinfo-data"
   spec.add_dependency "bcrypt"
   spec.add_dependency "pagy"
-  spec.add_dependency "acts_as_list"
   spec.add_dependency "turbo-rails"
   spec.add_dependency "stimulus-rails"
   spec.add_dependency "importmap-rails"

--- a/lib/hyper-kitten-meow.rb
+++ b/lib/hyper-kitten-meow.rb
@@ -1,7 +1,6 @@
 require "human_urls"
 require "categorical"
 require "pagy"
-require "acts_as_list"
 require "importmap-rails"
 require "stimulus-rails"
 require "propshaft"


### PR DESCRIPTION
Follow-up to #20.

`acts_as_list` was declared as a gem dependency (`hyper-kitten-meow.gemspec`) and required at boot (`lib/hyper-kitten-meow.rb`), but nothing in the engine uses it — no `acts_as_list` calls, no `position` column anywhere. The named-slots content-block model gets its render order from each template's `view_template`, not from data, so list ordering is never needed.

## Changes
- Remove the `acts_as_list` gemspec dependency and the `require`.
- Regenerate `Gemfile.lock`.

## Tests
79 examples, 0 failures — the app boots and the suite passes without the gem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)