### PR TITLE
Add mise dev environment (hybrid: local Ruby + Dockerized tests)

### DIFF
--- a/.devbox/docker-compose.yml
+++ b/.devbox/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: hyper
       POSTGRES_PASSWORD: kitten
     ports:
-      - '5432:5432'
+      - '5433:5432'
     volumes:
       - pgdata:/var/lib/postgresql/data
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.21)
     bigdecimal (4.0.1)
@@ -151,6 +152,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.0)
       crass (~> 1.0.2)
@@ -186,6 +189,10 @@ GEM
     pagy (43.2.2)
       json
       yaml
+    parallel (2.1.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
     pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
     phlex (2.3.1)
@@ -253,6 +260,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
+    rainbow (3.1.1)
     rake (13.3.1)
     rdoc (7.0.3)
       erb
@@ -279,6 +287,25 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.6)
+    rubocop (1.87.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    ruby-progressbar (1.13.0)
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
@@ -290,6 +317,18 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    standard (1.55.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.87.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.8)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.9.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.26.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -303,6 +342,9 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2025.3)
       tzinfo (>= 1.0.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
     websocket (1.2.11)
@@ -319,6 +361,7 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-25
 
 DEPENDENCIES
   capybara
@@ -328,6 +371,7 @@ DEPENDENCIES
   puma
   rspec-rails
   selenium-webdriver
+  standard
 
 RUBY VERSION
    ruby 3.4.1p0

--- a/hyper-kitten-meow.gemspec
+++ b/hyper-kitten-meow.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "selenium-webdriver"
   spec.add_development_dependency "puma"
+  spec.add_development_dependency "standard"
 end

--- a/mise.toml
+++ b/mise.toml
@@ -2,13 +2,17 @@
 ruby = "3.4.1"
 
 [env]
+# Local tasks reach the Dockerized Postgres over its published port.
+# (5432 is already taken by Postgres.app, so the container publishes 5433.)
 APP_DB_HOST = "localhost"
+APP_DB_PORT = "5433"
 APP_DB_USERNAME = "hyper"
 APP_DB_PASSWORD = "kitten"
 
-[tasks.test]
-description = "Run the RSpec suite"
-run = "bundle exec rspec spec"
+[vars]
+compose = "docker-compose -f .devbox/docker-compose.yml"
+
+# --- Local Ruby (fast loop + editor tooling) ---
 
 [tasks.lint]
 description = "Run standardrb"
@@ -20,31 +24,53 @@ run = "bundle exec standardrb --fix"
 
 [tasks.dev]
 description = "Start the dummy app on http://localhost:3000"
+depends = ["db:up"]
 run = "spec/dummy/bin/rails server"
 
 [tasks.console]
 description = "Open a Rails console in the dummy app"
+depends = ["db:up"]
 run = "spec/dummy/bin/rails console"
 
-[tasks."db:init"]
-description = "Create the 'hyper' Postgres role (idempotent)"
+# --- Postgres (Docker) ---
+
+[tasks."db:up"]
+description = "Start Postgres and wait until it accepts connections"
 run = """
-psql -h "$APP_DB_HOST" -d postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='hyper'" | grep -q 1 \
-  || psql -h "$APP_DB_HOST" -d postgres -c "CREATE ROLE hyper LOGIN SUPERUSER PASSWORD 'kitten'"
+{{vars.compose}} up -d db
+until {{vars.compose}} exec -T db pg_isready -U hyper -q; do sleep 0.5; done
 """
+
+[tasks."db:down"]
+description = "Stop Postgres"
+run = "{{vars.compose}} stop db"
 
 [tasks."db:setup"]
 description = "Create and load the development + test databases"
-depends = ["db:init"]
+depends = ["db:up"]
 run = """
 cd spec/dummy
 RAILS_ENV=development bin/rails db:create db:schema:load
 RAILS_ENV=test bin/rails db:create db:schema:load
 """
 
+# --- Tests (Docker: chromium baked into the image) ---
+
+[tasks.build]
+description = "Build the web image used to run the suite"
+run = "{{vars.compose}} build web"
+
+[tasks.test]
+description = "Run the RSpec suite in Docker"
+depends = ["db:up"]
+run = "{{vars.compose}} run --rm web bundle exec rspec spec"
+
+# --- Bootstrap ---
+
 [tasks.setup]
-description = "Bootstrap the project for development"
+description = "Install deps, build the test image, and prepare the databases"
 run = """
 bundle install
+{{vars.compose}} build web
 mise run db:setup
 """

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,50 @@
+[tools]
+ruby = "3.4.1"
+
+[env]
+APP_DB_HOST = "localhost"
+APP_DB_USERNAME = "hyper"
+APP_DB_PASSWORD = "kitten"
+
+[tasks.test]
+description = "Run the RSpec suite"
+run = "bundle exec rspec spec"
+
+[tasks.lint]
+description = "Run standardrb"
+run = "bundle exec standardrb"
+
+[tasks."lint:fix"]
+description = "Autofix standardrb violations"
+run = "bundle exec standardrb --fix"
+
+[tasks.dev]
+description = "Start the dummy app on http://localhost:3000"
+run = "spec/dummy/bin/rails server"
+
+[tasks.console]
+description = "Open a Rails console in the dummy app"
+run = "spec/dummy/bin/rails console"
+
+[tasks."db:init"]
+description = "Create the 'hyper' Postgres role (idempotent)"
+run = """
+psql -h "$APP_DB_HOST" -d postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='hyper'" | grep -q 1 \
+  || psql -h "$APP_DB_HOST" -d postgres -c "CREATE ROLE hyper LOGIN SUPERUSER PASSWORD 'kitten'"
+"""
+
+[tasks."db:setup"]
+description = "Create and load the development + test databases"
+depends = ["db:init"]
+run = """
+cd spec/dummy
+RAILS_ENV=development bin/rails db:create db:schema:load
+RAILS_ENV=test bin/rails db:create db:schema:load
+"""
+
+[tasks.setup]
+description = "Bootstrap the project for development"
+run = """
+bundle install
+mise run db:setup
+"""

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   database: <%= ENV['APP_DB_NAME'] %>
   username: <%= ENV['APP_DB_USERNAME'] || 'root' %>
   password: <%= ENV['APP_DB_PASSWORD'] || '' %>
-  port: 5432
+  port: <%= ENV['APP_DB_PORT'] || 5432 %>
 
 development:
   <<: *default


### PR DESCRIPTION
## Summary

Adds a [mise](https://mise.jdx.dev/) dev environment with a **hybrid** runtime split:

- **Local Ruby (mise-managed)** for the fast inner loop and editor tooling — `lint`, `lint:fix`, `dev`, `console`.
- **Docker** for things that need pinned native deps — the **test** suite runs in the web image where `chromium`/`chromedriver`, `pg`, and `vips` are baked in.

A single Dockerized Postgres backs both. It's published on `5433` (since `5432` is commonly held by a host Postgres such as Postgres.app), and `database.yml` now honors `APP_DB_PORT`. Local tasks reach the DB via `localhost:5433`; the in-container suite reaches the same instance over the compose network (`db:5432`).

## Tasks

| Task | Where | Purpose |
|------|-------|---------|
| `lint` / `lint:fix` | local | standardrb |
| `dev` / `console` | local | dummy app server / Rails console (auto-starts DB) |
| `db:up` / `db:down` | Docker | start/stop Postgres |
| `db:setup` | local→Docker DB | create + load development and test databases |
| `build` | Docker | build the web image used for the suite |
| `test` | Docker | run RSpec (deterministic chromium) |
| `setup` | mixed | bundle install + build image + db setup |

Also adds `standard` as a dev dependency to back the `lint` task.

## Files
- `mise.toml` — tools + tasks (above)
- `.devbox/docker-compose.yml` — db port `5432:5432` → `5433:5432`
- `spec/dummy/config/database.yml` — `port: <%= ENV['APP_DB_PORT'] || 5432 %>`
- `hyper-kitten-meow.gemspec` / `Gemfile.lock` — add `standard`

## Notes
- Adding a gem requires `mise run build` to rebuild the test image.
- `standardrb` reports pre-existing offenses; left untouched here (run `mise run lint:fix` separately).

## Test plan
- `mise install`
- `mise run setup`
- `mise run db:setup` → local Rails connects to the Docker DB on 5433 and loads schema ✅
- `mise run test` → **82 examples, 0 failures** in Docker ✅
- `mise run lint` → runs standardrb locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)