### PR TITLE
Redirect admin entry points to first-run setup when no users exist

### DIFF
--- a/lib/hyper_kitten_meow/concerns/controllers/admin/admin_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/admin_controller.rb
@@ -16,7 +16,10 @@ module HyperKittenMeow
           end
 
           def authorize
-            raise ActionController::RoutingError.new("Not Found") unless logged_in?
+            return if logged_in?
+            redirect_to new_admin_first_user_path and return unless User.any?
+
+            raise ActionController::RoutingError.new("Not Found")
           end
 
           def current_user

--- a/spec/features/admin/create_first_user_spec.rb
+++ b/spec/features/admin/create_first_user_spec.rb
@@ -8,6 +8,12 @@ RSpec.feature "Creating the first user", :type => :feature do
       expect(page).to have_current_path(hyper_kitten_meow.new_admin_first_user_path)
     end
 
+    scenario "visiting any admin page redirects to the first user form" do
+      visit hyper_kitten_meow.admin_root_path
+
+      expect(page).to have_current_path(hyper_kitten_meow.new_admin_first_user_path)
+    end
+
     scenario "visitor can create first user" do
       visit hyper_kitten_meow.new_admin_first_user_path
 


### PR DESCRIPTION
## Problem

On a fresh install with no users, only `/admin/login` redirected to the first-run setup wizard. Hitting any other admin URL (`/admin`, `/admin/posts`, `/admin/tags`, `/admin/users`, …) raised a bare **404** — because `AdminController#authorize` checked login state before considering the no-users case, leaving a visitor with no way to discover setup.

## Fix

`authorize` now redirects to the first-user form whenever no users exist, so **any** admin entry point guides the visitor into setup. The existing 404 for logged-out visitors is preserved once a user exists (keeps the admin hidden from strangers).

```ruby
def authorize
  return if logged_in?
  redirect_to new_admin_first_user_path and return unless User.any?

  raise ActionController::RoutingError.new("Not Found")
end
```

## Behavior

| State | Before | After |
|---|---|---|
| No users, any admin URL | 404 | → first-run wizard |
| Users exist, logged out | 404 | 404 (unchanged) |
| Logged in | proceeds | proceeds |

## Verification

- Added a feature spec: "visiting any admin page redirects to the first user form."
- Full suite green: **83 examples, 0 failures**.
- Manually confirmed against the dummy app: with 0 users, `/admin`, `/admin/posts`, `/admin/tags`, `/admin/users` all `302 →` `first_users/new`; with a user present, `/admin` still `404`s when logged out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)