### PR TITLE
Default content_blocks to an empty array

### DIFF
--- a/lib/hyper_kitten_meow/components/base_page_template.rb
+++ b/lib/hyper_kitten_meow/components/base_page_template.rb
@@ -3,7 +3,9 @@ module HyperKittenMeow
     TEMPLATES_PATH = "app/views/pages/templates"
 
     class << self
-      attr_reader :content_blocks
+      def content_blocks
+        @content_blocks || []
+      end
 
       def title
         id.titleize

--- a/spec/dummy/app/views/pages/templates/blockless_test_template.rb
+++ b/spec/dummy/app/views/pages/templates/blockless_test_template.rb
@@ -1,0 +1,9 @@
+module Pages
+  module Templates
+    class BlocklessTestTemplate < HyperKittenMeow::BasePageTemplate
+      def view_template
+        h1 { "Built from models, no content blocks" }
+      end
+    end
+  end
+end

--- a/spec/lib/hyper_kitten_meow/components/base_page_template_spec.rb
+++ b/spec/lib/hyper_kitten_meow/components/base_page_template_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe HyperKittenMeow::BasePageTemplate do
+  describe ".content_blocks" do
+    it "is empty for a template that registers none" do
+      template = described_class.find_template("BlocklessTestTemplate")
+
+      expect(template.content_blocks).to eq([])
+    end
+
+    it "is the registered blocks otherwise" do
+      template = described_class.find_template("TestTemplate")
+
+      expect(template.content_blocks).to eq([:test_block, :test_block_two])
+    end
+  end
+
+  describe ".all_templates_and_blocks" do
+    it "includes templates that register no content blocks" do
+      expect(described_class.all_templates_and_blocks)
+        .to include("BlocklessTestTemplate" => {"blocksInfo" => []})
+    end
+  end
+end

--- a/spec/models/hyper_kitten_meow/page_spec.rb
+++ b/spec/models/hyper_kitten_meow/page_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe HyperKittenMeow::Page, type: :model do
   describe ".templates" do
     it "returns a list of available templates" do
       template_titles = HyperKittenMeow::Page.templates.map(&:title)
-      expect(template_titles).to match_array(["Another Test Template", "Test Template"])
+      expect(template_titles)
+        .to match_array(["Another Test Template", "Blockless Test Template", "Test Template"])
     end
   end
 


### PR DESCRIPTION
Fixes #25.

`BasePageTemplate.content_blocks` was a plain `attr_reader`, so a template that never called `register_content_blocks` left it `nil` and `all_templates_and_blocks` blew up on `nil.map`. Since that method is called from the admin pages controller, the error landed on the **page form** — every page in the admin became uneditable, and the backtrace pointed at a template you may not have touched.

## Fix

```ruby
def content_blocks
  @content_blocks || []
end
```

Defaulting the reader (rather than adding `.to_a` at the one call site) fixes every caller at once, and makes "registers no blocks" mean what it reads like instead of requiring a bare `register_content_blocks` to declare emptiness.

## Tests

- New dummy template `BlocklessTestTemplate` — the repro from the issue, a template built without content blocks.
- `spec/lib/hyper_kitten_meow/components/base_page_template_spec.rb` covers `.content_blocks` for both the blockless and registered cases, and `.all_templates_and_blocks` including the blockless template as `{"blocksInfo" => []}`.
- `Page.templates` assertion updated for the added dummy template.

Full suite: 86 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)