### PR TITLE
Use flash.now for admin failure banners

### DIFF
--- a/lib/hyper_kitten_meow/concerns/controllers/admin/first_users_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/first_users_controller.rb
@@ -23,7 +23,7 @@ module HyperKittenMeow
               flash[:success] = "User successfully created. Please log in."
               redirect_to admin_login_path
             else
-              flash[:error] = "There was a problem saving the user."
+              flash.now[:error] = "There was a problem saving the user."
               render Views::Admin::FirstUsers::New.new(user: @user), status: :unprocessable_entity
             end
           end

--- a/lib/hyper_kitten_meow/concerns/controllers/admin/pages_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/pages_controller.rb
@@ -25,7 +25,7 @@ module HyperKittenMeow
               flash[:success] = "Page successfully created."
               redirect_to admin_pages_path
             else
-              flash[:error] = @page.errors.full_messages.join(", ")
+              flash.now[:error] = @page.errors.full_messages.join(", ")
               render Views::Admin::Pages::New.new(page: @page, templates_and_content_blocks: @templates_and_content_blocks), status: :unprocessable_entity
             end
           end
@@ -43,7 +43,7 @@ module HyperKittenMeow
               flash[:success] = "Page was successfully updated."
               redirect_to admin_pages_path
             else
-              flash[:error] = "There was a problem saving the page."
+              flash.now[:error] = "There was a problem saving the page."
               render Views::Admin::Pages::Edit.new(page: @page, templates_and_content_blocks: @templates_and_content_blocks), status: :unprocessable_entity
             end
           end

--- a/lib/hyper_kitten_meow/concerns/controllers/admin/posts_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/posts_controller.rb
@@ -21,7 +21,7 @@ module HyperKittenMeow
               flash[:success] = "Post successfully created."
               redirect_to admin_posts_path
             else
-              flash[:error] = "There was a problem saving the post."
+              flash.now[:error] = "There was a problem saving the post."
               render Views::Admin::Posts::New.new(post: @post), status: :unprocessable_entity
             end
           end
@@ -37,7 +37,7 @@ module HyperKittenMeow
               flash[:success] = "Post was successfully updated."
               redirect_to admin_posts_path
             else
-              flash[:error] = "There was a problem saving the post."
+              flash.now[:error] = "There was a problem saving the post."
               render Views::Admin::Posts::Edit.new(post: @post), status: :unprocessable_entity
             end
           end

--- a/lib/hyper_kitten_meow/concerns/controllers/admin/tags_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/tags_controller.rb
@@ -21,7 +21,7 @@ module HyperKittenMeow
               flash[:success] = "Tag successfully created."
               redirect_to admin_tags_path
             else
-              flash[:error] = "There was a problem saving the tag."
+              flash.now[:error] = "There was a problem saving the tag."
               render Views::Admin::Tags::New.new(tag: @tag), status: :unprocessable_entity
             end
           end
@@ -37,7 +37,7 @@ module HyperKittenMeow
               flash[:success] = "Tag was successfully updated."
               redirect_to admin_tags_path
             else
-              flash[:error] = "There was a problem saving the tag."
+              flash.now[:error] = "There was a problem saving the tag."
               render Views::Admin::Tags::Edit.new(tag: @tag), status: :unprocessable_entity
             end
           end

--- a/lib/hyper_kitten_meow/concerns/controllers/admin/users_controller.rb
+++ b/lib/hyper_kitten_meow/concerns/controllers/admin/users_controller.rb
@@ -21,7 +21,7 @@ module HyperKittenMeow
               flash[:success] = "User successfully created."
               redirect_to admin_users_path
             else
-              flash[:error] = "There was a problem saving the user."
+              flash.now[:error] = "There was a problem saving the user."
               render Views::Admin::Users::New.new(user: @user), status: :unprocessable_entity
             end
           end
@@ -37,7 +37,7 @@ module HyperKittenMeow
               flash[:success] = "User was successfully updated."
               redirect_to admin_users_path
             else
-              flash[:error] = "There was a problem saving the user."
+              flash.now[:error] = "There was a problem saving the user."
               render Views::Admin::Users::Edit.new(user: @user), status: :unprocessable_entity
             end
           end

--- a/spec/features/admin/posts/new_spec.rb
+++ b/spec/features/admin/posts/new_spec.rb
@@ -36,4 +36,18 @@ RSpec.feature "Admin posts new", type: :feature do
 
     expect(page).to have_text("Title can't be blank")
   end
+
+  scenario "the failure banner does not follow the user to the next page" do
+    create_user_and_login
+    visit hyper_kitten_meow.new_admin_post_path
+
+    fill_in "Title", with: ""
+    click_on "Create Post"
+
+    expect(page).to have_text("There was a problem saving the post.")
+
+    visit hyper_kitten_meow.admin_posts_path
+
+    expect(page).not_to have_text("There was a problem saving the post.")
+  end
 end


### PR DESCRIPTION
Fixes #29.

The create and update failure paths in the admin controllers `render` rather than redirect, but set a plain `flash[:error]`. Since nothing consumes it on that request, the banner survives into the *next* one — fail to save, navigate anywhere, and the stale "There was a problem saving the post." comes with you.

## Changes

`flash.now[:error]` on all nine render paths:

| File | Lines |
| --- | --- |
| `posts_controller.rb` | 24, 40 |
| `pages_controller.rb` | 28, 46 |
| `tags_controller.rb` | 24, 40 |
| `users_controller.rb` | 24, 40 |
| `first_users_controller.rb` | 26 |

`Components::Flash` reads `flash.to_hash`, which includes `flash.now` values for the current request, so the banner still shows on the failed render. The `flash[:success]` assignments are untouched — those precede a `redirect_to` and are correct.

## Test

`spec/features/admin/posts/new_spec.rb` gains a scenario pinning both halves. Confirmed it fails against the pre-fix controller:

```
expected not to find text "There was a problem saving the post." in
"... Admin\nThere was a problem saving the post.\n0 total · 0 published\nPosts ..."
```

Full suite: 87 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)