### PR TITLE
Let the host app brand the admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ There currently is no theme in place, so the views will have to be styled themse
 
 If you duplicate these files and directories in your project you can override the views and customize them however you like.
 
+### Branding
+
+The admin wordmark reads from the same `title` translation as the browser tab, so
+setting it in your `en.yml` brands both:
+
+```yaml
+en:
+  title: 'Susquehanna Footprints'
+```
+
+For a different mark, or no mark at all, override `sidebar_brand` in a
+`Views::Admin::Base` subclass. It may return anything Phlex can render — a
+component, a class, a proc, or a string — and `nil` keeps the engine wordmark:
+
+```ruby
+def sidebar_brand
+  Components::Wordmark.new(text: "Susquehanna Footprints", mark: "sf-mark.svg", light: true)
+end
+```
+
+Pass `light: true` for anything you render there: the sidebar is dark, and the
+wordmark's default ink color is meant for light backgrounds. `mark: false` drops
+the image and leaves the text alone.
+
+If you render `Components::Sidebar` yourself, it takes the same thing as `brand:`.
+
 ### Icons
 
 `Components::Icon` inlines an SVG by name: `render Components::Icon.new("calendar-days")`,

--- a/app/views/hyper_kitten_meow/components/sidebar.rb
+++ b/app/views/hyper_kitten_meow/components/sidebar.rb
@@ -5,13 +5,16 @@ module HyperKittenMeow
     include Phlex::Rails::Helpers::LinkTo
     include Phlex::Rails::Helpers::Request
 
-    def initialize(light: true)
+    def initialize(light: true, brand: nil)
       @light = light
+      @brand = brand
     end
 
     def view_template(&block)
       nav(class: "mw-sidebar") do
-        div(class: "mw-sidebar__brand") { render Components::Wordmark.new(light: @light) }
+        div(class: "mw-sidebar__brand") do
+          render(@brand || Components::Wordmark.new(light: @light))
+        end
         yield(self) if block_given?
       end
     end

--- a/app/views/hyper_kitten_meow/components/wordmark.rb
+++ b/app/views/hyper_kitten_meow/components/wordmark.rb
@@ -3,23 +3,40 @@
 module HyperKittenMeow
   class Components::Wordmark < Components::Base
     include Phlex::Rails::Helpers::AssetPath
+    include Phlex::Rails::Helpers::T
 
-    def initialize(light: false, mark_only: false)
+    MARK = "hyper_kitten_meow/meow-mark.svg"
+    LIGHT_MARK = "hyper_kitten_meow/meow-mark-light.svg"
+
+    def initialize(light: false, mark_only: false, text: nil, mark: nil)
       @light = light
       @mark_only = mark_only
+      @text = text
+      @mark = mark
     end
 
     def view_template
-      mark = @light ? "hyper_kitten_meow/meow-mark-light.svg" : "hyper_kitten_meow/meow-mark.svg"
       span(class: ["mw-wordmark", ("mw-wordmark--light" if @light)]) do
-        img(src: asset_path(mark), alt: "Meow")
+        img(src: asset_path(mark), alt: text) if mark
         unless @mark_only
           span(class: "mw-wordmark__text") do
-            plain "Meow"
+            plain text
             span(class: "dot") { "." }
           end
         end
       end
+    end
+
+    private
+
+    def text
+      @text || t("title")
+    end
+
+    def mark
+      return @mark unless @mark.nil?
+
+      @light ? LIGHT_MARK : MARK
     end
   end
 end

--- a/app/views/hyper_kitten_meow/views/admin/base.rb
+++ b/app/views/hyper_kitten_meow/views/admin/base.rb
@@ -20,6 +20,10 @@ module HyperKittenMeow
       javascript_importmap_tags("hyper_kitten_meow/application")
     end
 
+    def sidebar_brand
+      nil
+    end
+
     def around_template(&block)
       super do
         if render_chrome?
@@ -41,7 +45,7 @@ module HyperKittenMeow
     private
 
     def render_sidebar
-      render Components::Sidebar.new do |s|
+      render Components::Sidebar.new(brand: sidebar_brand) do |s|
         next unless logged_in?
 
         s.section "Manage"

--- a/spec/views/hyper_kitten_meow/components/sidebar_spec.rb
+++ b/spec/views/hyper_kitten_meow/components/sidebar_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HyperKittenMeow::Components::Sidebar, type: :view do
+  describe "the brand" do
+    it "renders the engine wordmark by default" do
+      render described_class.new
+
+      expect(rendered).to have_css("nav.mw-sidebar div.mw-sidebar__brand span.mw-wordmark")
+      expect(rendered).to have_css("div.mw-sidebar__brand img[src*='meow-mark']", visible: :all)
+    end
+
+    it "renders the light wordmark on a dark sidebar" do
+      render described_class.new(light: true)
+
+      expect(rendered).to have_css("div.mw-sidebar__brand span.mw-wordmark--light")
+    end
+
+    it "renders a host-supplied component instead" do
+      brand = HyperKittenMeow::Components::Wordmark.new(text: "Susquehanna Footprints", mark: false)
+
+      render described_class.new(brand: brand)
+
+      expect(rendered).to have_css("div.mw-sidebar__brand", text: "Susquehanna Footprints.")
+      expect(rendered).to have_no_css("div.mw-sidebar__brand img", visible: :all)
+    end
+
+    it "renders a host-supplied string" do
+      render described_class.new(brand: "Susquehanna Footprints")
+
+      expect(rendered).to have_css("div.mw-sidebar__brand", text: "Susquehanna Footprints")
+      expect(rendered).to have_no_css("div.mw-sidebar__brand span.mw-wordmark")
+    end
+  end
+
+  describe "the menu" do
+    it "still renders items alongside a replaced brand" do
+      render described_class.new(brand: "Footprints") { |s|
+        s.section "Manage"
+        s.menu { s.item "Episodes", "/admin/episodes", icon: "mic" }
+      }
+
+      expect(rendered).to have_css("div.mw-sidebar__brand", text: "Footprints")
+      expect(rendered).to have_css("span.mw-sidebar__section", text: "Manage")
+      expect(rendered).to have_css("div.mw-nav a.mw-nav__item[href='/admin/episodes']", text: "Episodes")
+      expect(rendered).to have_css("a.mw-nav__item svg.lucide-mic", visible: :all)
+    end
+  end
+end

--- a/spec/views/hyper_kitten_meow/components/wordmark_spec.rb
+++ b/spec/views/hyper_kitten_meow/components/wordmark_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HyperKittenMeow::Components::Wordmark, type: :view do
+  describe "brand text" do
+    it "uses the site title so the sidebar and the browser tab agree" do
+      render described_class.new
+
+      expect(rendered).to have_css("span.mw-wordmark__text", text: "#{I18n.t('title')}.")
+    end
+
+    it "follows the host app's title translation" do
+      # Load the yaml first: storing into an uninitialized backend is discarded
+      # when the first lookup loads the translation files over it.
+      I18n.backend.load_translations
+      I18n.backend.store_translations(:en, title: "Susquehanna Footprints")
+
+      render described_class.new
+
+      expect(rendered).to have_css("span.mw-wordmark__text", text: "Susquehanna Footprints.")
+    ensure
+      I18n.backend.reload!
+    end
+
+    it "accepts text passed directly" do
+      render described_class.new(text: "Hyper Kitten")
+
+      expect(rendered).to have_css("span.mw-wordmark__text", text: "Hyper Kitten.")
+    end
+
+    it "describes the mark with the brand text" do
+      render described_class.new(text: "Hyper Kitten")
+
+      expect(rendered).to have_css("img[alt='Hyper Kitten']", visible: :all)
+    end
+
+    it "omits the text when only the mark is wanted" do
+      render described_class.new(mark_only: true)
+
+      expect(rendered).to have_no_css("span.mw-wordmark__text")
+      expect(rendered).to have_css("img", visible: :all)
+    end
+  end
+
+  describe "the mark" do
+    it "defaults to the engine's mark" do
+      render described_class.new
+
+      expect(rendered).to have_css("img[src*='meow-mark']", visible: :all)
+    end
+
+    it "uses the light mark on a dark background" do
+      render described_class.new(light: true)
+
+      expect(rendered).to have_css("span.mw-wordmark.mw-wordmark--light")
+      expect(rendered).to have_css("img[src*='meow-mark-light']", visible: :all)
+    end
+
+    it "accepts a host app's own mark" do
+      render described_class.new(mark: "hyper_kitten_meow/meow-mark-orange.svg")
+
+      expect(rendered).to have_css("img[src*='meow-mark-orange']", visible: :all)
+    end
+
+    it "renders text alone when the mark is declined" do
+      render described_class.new(mark: false, text: "Susquehanna Footprints")
+
+      expect(rendered).to have_no_css("img", visible: :all)
+      expect(rendered).to have_css("span.mw-wordmark__text", text: "Susquehanna Footprints.")
+    end
+  end
+end

--- a/spec/views/hyper_kitten_meow/views/admin/base_spec.rb
+++ b/spec/views/hyper_kitten_meow/views/admin/base_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HyperKittenMeow::Views::Admin::Base, type: :view do
+  describe "#sidebar_brand" do
+    it "leaves the engine wordmark in place when the host app has no brand of its own" do
+      view = described_class.new
+      allow(view).to receive(:logged_in?).and_return(false)
+
+      render view
+
+      expect(rendered).to have_css("div.mw-sidebar__brand span.mw-wordmark")
+    end
+
+    it "renders whatever a host app subclass returns" do
+      branded = Class.new(described_class) do
+        def sidebar_brand
+          HyperKittenMeow::Components::Wordmark.new(
+            text: "Susquehanna Footprints", mark: false, light: true
+          )
+        end
+      end
+      view = branded.new
+      allow(view).to receive(:logged_in?).and_return(false)
+
+      render view
+
+      expect(rendered).to have_css("div.mw-sidebar__brand", text: "Susquehanna Footprints.")
+      expect(rendered).to have_no_css("div.mw-sidebar__brand img", visible: :all)
+    end
+
+    it "brands the browser tab from the same translation the wordmark uses" do
+      # Load the yaml first: storing into an uninitialized backend is discarded
+      # when the first lookup loads the translation files over it.
+      I18n.backend.load_translations
+      I18n.backend.store_translations(:en, title: "Susquehanna Footprints")
+      view = described_class.new
+      allow(view).to receive(:logged_in?).and_return(false)
+
+      render view
+
+      expect(view.page_title).to eq("Susquehanna Footprints - Admin")
+      expect(rendered).to have_css("div.mw-sidebar__brand", text: "Susquehanna Footprints.")
+    ensure
+      I18n.backend.reload!
+    end
+  end
+end


### PR DESCRIPTION
Fixes #27.

`Components::Wordmark` hardcoded both the text and the mark, so every host app's admin read "Meow." — the engine's name rather than the site's. Before the Phlex conversion the brand lived in the overridable admin layout; after it there was no way to change it short of abandoning `Components::Sidebar`.

## Three layers, smallest first

**`t("title")` brands the wordmark.** The text now defaults to the same key `Views::Admin::Base#page_title` already uses, so one line of `en.yml` brands the sidebar, the login screen, the setup screen and the browser tab together:

```yaml
en:
  title: 'Susquehanna Footprints'
```

This is deliberately the layer that needs no hooks. `render_sidebar` is private, so the block form the issue sketched (`s.brand { ... }`) would be unreachable from a host app until #26 lands — i18n works today.

**`Wordmark` takes `text:` and `mark:`.** `mark: false` drops the image for a text-only brand, and `alt` follows the text instead of saying "Meow".

**`sidebar_brand` on `Views::Admin::Base`**, returning `nil` by default, plus `brand:` on `Components::Sidebar` for apps that render it themselves. Both are permissive — anything `Phlex::SGML#render` handles: component, class, proc, string, enumerable.

```ruby
def sidebar_brand
  Components::Wordmark.new(text: "Susquehanna Footprints", mark: "sf-mark.svg", light: true)
end
```

## Behavior change worth a look

**Apps that never set `title` will see "Your Title." in the sidebar instead of "Meow."** — which is exactly what their browser tab has always shown, since `page_title` reads the same key.

The issue asked for a default where "nothing changes for apps that don't care," and strictly this changes for them. I went with the issue's other suggestion (reuse the `title` key) because a sidebar and tab disagreeing seems worse than a placeholder, and "Your Title." prompts you to set the key while "Meow." silently ships someone else's brand. Say the word if you'd rather have a "Meow" fallback when the key is untouched.

## Sharp edge, documented not fixed

The sidebar knows it's on a dark background; a host-supplied brand doesn't. Anything returned from `sidebar_brand` needs `light: true` or its text renders in `--ink` against the dark sidebar. We chose the permissive contract over narrowing the hook to a `{text:, mark:}` hash — full replacement stays possible, and the mistake is visible the moment you load the page. The README says so explicitly.

## Testing

17 new examples — wordmark text/mark/light/mark_only combinations, sidebar brand defaults and replacement by component/string, menu items rendering alongside a replaced brand, and the `sidebar_brand` override reaching the sidebar with the tab and wordmark agreeing. Full suite **116 examples, 0 failures**, view specs verified across three seeds.

One of my specs initially failed on an I18n trap worth knowing about: `store_translations` into an uninitialized backend is silently overwritten when the first lookup loads the YAML files over it. Fixed with an explicit `load_translations` and a comment.

Scope: this does not touch #26 — the menu still can't be extended, and `sidebar_brand` composes with whatever registry that issue settles on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)